### PR TITLE
Add Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,27 @@
+language: node_js
+node_js:
+    - "10"
+stages:
+  - test
+  - name: documentation
+    if: branch = master
+jobs:
+  include:
+    - stage: test
+      script:
+      - npm run typecheck
+      - npm run lint
+      - npm run test
+      - npm run codecov
+    - stage: documentation
+      script:
+        - npm run build
+        - touch ./styleguide/.nojekyll
+      deploy:
+        provider: pages
+        skip_cleanup: true
+        github_token: $GITHUB_TOKEN
+        local_dir: ./styleguide
+        target_branch: gh-pages
+        on:
+          branch: master


### PR DESCRIPTION
Adds a slightly modified version of our default `.travis.yml` file, primarily removing the docker related things.

Note that this will fail on Travis, since we don't actually have any code in here yet and there are some type collision issues that I'll be resolving in a separate PR.