### PR TITLE
Add test-utils with custom render method

### DIFF
--- a/src/Button/__tests__/BasicButton.test.tsx
+++ b/src/Button/__tests__/BasicButton.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent } from 'test-utils';
 import { spy } from 'sinon';
 import assert from 'assert';
 import BasicButton from '../BasicButton';

--- a/src/__tests__/utils/customRender.ts
+++ b/src/__tests__/utils/customRender.ts
@@ -1,0 +1,23 @@
+import { ReactElement } from 'react';
+import {
+  render,
+  RenderResult,
+  RenderOptions,
+} from '@testing-library/react';
+import { MarkOneWrapper } from 'mark-one';
+
+/**
+ * In order to use our theme context in tests, we need to wrap all of our
+ * rendered components in the [[MarkOneWrapper]]. Since that sounds tedious, we
+ * can instead re-define the `render` function, then export from this module
+ * and create a ts-paths alias to 'test-utils'
+ */
+
+const customRender = (
+  ui: ReactElement,
+  options?: RenderOptions
+): RenderResult => render(ui, { wrapper: MarkOneWrapper, ...options });
+
+
+export * from '@testing-library/react';
+export { customRender as render };

--- a/src/__tests__/utils/index.ts
+++ b/src/__tests__/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './customRender';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,11 +24,14 @@
     "baseUrl": "./src",
     "incremental": true,
     "paths": {
-      "testData": [
-        "/__tests__/data/index.ts"
+      "test-data": [
+        "./__tests__/data/index.ts"
+      ],
+      "test-utils": [
+        "./__tests__/utils/index.ts"
       ],
       "mark-one": [
-        "index.ts"
+        "./index.ts"
       ]
     }
   },


### PR DESCRIPTION
In order to wrap all of our rendered components in the MarkOneWrapper, we can redefine the render function from @testing-library/react, then create a tsconfig path alias to a new 'test-utils' module that can be used in our tests instead.

See: https://testing-library.com/docs/react-testing-library/setup