### PR TITLE
Remove TableCell.md

### DIFF
--- a/examples/TableCell/TableCell.md
+++ b/examples/TableCell/TableCell.md
@@ -1,5 +1,0 @@
-```jsx
-<TableCell>1/1/20</TableCell>
-<TableCell>Symphony Hall</TableCell>
-<TableCell>Boston Pops</TableCell>
-```


### PR DESCRIPTION
Example for TableCell will be included in the Table.md file, so this TableCell.md is not needed.