### PR TITLE
Improve TableRow component

### DIFF
--- a/src/Table/TableRow.tsx
+++ b/src/Table/TableRow.tsx
@@ -35,4 +35,6 @@ TableRow.defaultProps = {
   isStriped: false,
 };
 
+declare type TableRow = ReactElement<TableRowProps>;
+
 export default TableRow;


### PR DESCRIPTION
Update the naming of RowProps to TableRowProps for consistency purposes. 

Also, include `declare type TableRow = ReactElement<TableRowProps>;` so that we can set the type for TableHead's children as TableRow. 