### PR TITLE
Only automate publishing the develop branch to npm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,8 @@ stages:
   - test
   - name: documentation
     if: branch = master AND type != pull_request
-  - name: version_bump 
-    if: branch IN (master,develop) AND type != pull_request
-  - name: npm_publish 
-    if: tag =~ /^v\d+\.\d+\.\d+\$/
+  - name: npm_deploy_develop
+    if: branch = develop AND type != pull_request
 jobs:
   include:
     - stage: test
@@ -28,14 +26,10 @@ jobs:
         target_branch: gh-pages
         on:
           branch: master
-    - stage: version_bump
-      script: "./.travis_version_bump.sh"
-    - stage: npm_publish
-      before_deploy: '[[ $TRAVIS_BRANCH == master ]] && NPM_TAG = latest || NPM_TAG = develop'
+    - stage: npm_deploy_develop
+      before_deploy: "./.travis_version_bump.sh"
       deploy:
         provider: npm
         email: $DEV_TEAM_EMAIL 
         api_key: $NPM_TOKEN
-        tag: $NPM_TAG
-        on:
-          tags: true
+        tag: develop

--- a/.travis_version_bump.sh
+++ b/.travis_version_bump.sh
@@ -1,32 +1,25 @@
 #!/bin/bash
 
-# Set the user name and email to match the API token holder
-git config --global user.email $DEV_TEAM_EMAIL 
-git config --global user.name "SEAS Computing Robot"
-git config --global push.default matching
-
-# Get the credentials from a file
-git config credential.helper "store --file=.git/credentials"
-
-# This associates the API Key with the account
-echo "https://${GITHUB_TOKEN}:@github.com" > .git/credentials
-
-git checkout -- .
-  
-# %s is the placeholder for the created tag
-if [[ $TRAVIS_BRANCH == master ]]; then
-  SEMVER=minor
-fi
-
 if [[ "$TRAVIS_BRANCH" == develop ]]; then 
-  SEMVER=patch
+
+  # Set the user name and email to match the API token holder
+  git config --local user.email $DEV_TEAM_EMAIL 
+  git config --local user.name "SEAS Computing Robot"
+  git config --local push.default matching
+
+  # Get the credentials from a file
+  git config credential.helper "store --file=.git/credentials"
+
+  # This associates the API Key with the account
+  echo "https://${GITHUB_TOKEN}:@github.com" > .git/credentials
+  
+  # Local branch must be clean before bumping version
+  git checkout -- .
+
+  npm version prerelease --preid=develop -m "[skip ci] Automatic bump to %s"
+  git push --tags origin HEAD:$TRAVIS_BRANCH
 fi
 
-if [[ "$SEMVER" != "" ]]; then
-  npm version $SEMVER -m "automatic bump to %s [skip ci]"
-fi
-
-git push --tags origin HEAD:$TRAVIS_BRANCH
 
 # Adapted from https://dev.to/jeffreymfarley/deploy-atomically-with-travis--npm-68b
 # By Jeff Farley

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mark-one",
-  "version": "0.0.2",
+  "version": "0.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mark-one",
-  "version": "0.0.4",
+  "version": "0.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mark-one",
-  "version": "0.0.2",
+  "version": "0.0.1",
   "description": "A UI component library for building React Apps",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",


### PR DESCRIPTION
This tweaks the process set up in #35 by removing the automatic deployment of the master branch at a new minor version, and changes the develop branch to deploy as a prerelease version (tagged as `-release`) instead of a patch version. 

Since we're removing the automation on the master branch and thus leaving out a lot of the conditional checks, I think we can also safely combine the version bump and npm publish into a single stage.