### PR TITLE
Update VARIANT import to have relative paths

### DIFF
--- a/src/Buttons/BorderlessButton.tsx
+++ b/src/Buttons/BorderlessButton.tsx
@@ -2,8 +2,8 @@ import React, {
   FunctionComponent, ReactElement, useContext, MouseEventHandler,
 } from 'react';
 import styled, { ThemeContext } from 'styled-components';
-import { VARIANT } from 'Theme/MarkOneTheme';
 import { FontAwesomeIconProps } from '@fortawesome/react-fontawesome';
+import { VARIANT } from '../Theme/MarkOneTheme';
 import { BaseTheme } from '../Theme';
 
 export interface BorderlessButtonProps {

--- a/src/Buttons/Button.tsx
+++ b/src/Buttons/Button.tsx
@@ -5,8 +5,8 @@ import React, {
   ReactNode,
   MouseEventHandler,
 } from 'react';
-import { VARIANT } from 'Theme/MarkOneTheme';
 import styled, { ThemeContext } from 'styled-components';
+import { VARIANT } from '../Theme/MarkOneTheme';
 import { BaseTheme } from '../Theme';
 
 export interface ButtonProps {

--- a/src/Buttons/__tests__/BorderlessButton.test.tsx
+++ b/src/Buttons/__tests__/BorderlessButton.test.tsx
@@ -10,9 +10,9 @@ import {
   SinonSpy,
 } from 'sinon';
 import assert from 'assert';
-import { VARIANT } from 'Theme/MarkOneTheme';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faArrowUp } from '@fortawesome/free-solid-svg-icons';
+import { VARIANT } from '../../Theme/MarkOneTheme';
 import BorderlessButton from '../BorderlessButton';
 
 describe('Borderless Button', function () {

--- a/src/Buttons/__tests__/Button.test.tsx
+++ b/src/Buttons/__tests__/Button.test.tsx
@@ -10,7 +10,7 @@ import {
   SinonSpy,
 } from 'sinon';
 import assert from 'assert';
-import { VARIANT } from 'Theme/MarkOneTheme';
+import { VARIANT } from '../../Theme/MarkOneTheme';
 import Button from '../Button';
 
 describe('Button', function () {


### PR DESCRIPTION
Instead of importing `VARIANT` enum directly from the `Theme` path, update the path to be relative to solve course-planner import error in which the `Button` and `BorderlessButton` components could not be found.

## Types of changes
<!--
  What types of changes does your code introduce? Put an `x` in all the boxes
  that apply:
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
<!--
  Go over all the following points, and put an `x` in all the boxes that apply.
-->
- [x] I have run `eslint` on the code
- [x] I have added JSDoc for all of my code (where applicable)
- [ ] I have added tests to cover my changes.

## Priority:
- [x] Normal <!-- New piece of functionality -->
- [ ] High <!-- Critical bug requiring urgent review -->

## Related Issues:
<!--
  Add the issue number in below that this PR is intended to address.

  Also mention any issues that this PR is related to, and if possible,
  provide more information regarding the relationship to the issues in
  question (i.e does the PR fix the issue, is it designed to fix another bug
  that is similar to the issue etc.)
-->
Addresses [#117](https://github.com/seas-computing/course-planner/issues/117)

<!--
  Attribution:
  PR Template adapted from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->