### PR TITLE
Remove drop-shadow from header

### DIFF
--- a/src/Layout/Header.tsx
+++ b/src/Layout/Header.tsx
@@ -26,7 +26,6 @@ export interface HeaderProps {
 const Header = styled.header<HeaderProps>`
   align-items: flex-end;
   background-color: ${({ background }): string => background};
-  box-shadow: ${({ theme }): string => theme.shadow.light};
   display: flex;
   justify-content: ${({ justify }): string => justify};
   padding: ${({ theme }): string => `${theme.ws.medium} ${theme.ws.small}`};


### PR DESCRIPTION
Header drop-shadow was making it difficult to integrate header tabs into the rest of the page. As discussed in a sprint planning meeting, this should be removed

Before:  
![image](https://user-images.githubusercontent.com/50675045/75815902-35434280-5d62-11ea-8a22-e4712be6d38a.png)


After:   
![image](https://user-images.githubusercontent.com/50675045/75816004-5c9a0f80-5d62-11ea-9ede-af490388dc6f.png)



