### PR TITLE
Table & TableCell Components: Remove Table margin and add TableCell alignment prop

### DIFF
--- a/examples/Tables/Table.md
+++ b/examples/Tables/Table.md
@@ -1,5 +1,14 @@
+The following is an example of the `Table` component with the `alignment` prop set to the enum value `ALIGN.LEFT.`
 ```jsx
-import { Table, TableCell, TableBody, TableRow, TableHeadingCell, TableHead } from 'mark-one';
+import {
+  ALIGN,
+  Table,
+  TableCell,
+  TableBody,
+  TableRow,
+  TableHeadingCell,
+  TableHead,
+} from 'mark-one';
 <Table>
   <TableHead>
     <TableRow>
@@ -10,34 +19,112 @@ import { Table, TableCell, TableBody, TableRow, TableHeadingCell, TableHead } fr
   </TableHead>
   <TableBody isScrollable={true}>
     <TableRow isStriped={true}>
-      <TableCell>1</TableCell>
-      <TableCell>Kristin</TableCell>
-      <TableCell>Glenn</TableCell>
+      <TableCell alignment={ALIGN.LEFT} foo="blue">1</TableCell>
+      <TableCell alignment={ALIGN.LEFT} foo="blue">Kristin</TableCell>
+      <TableCell alignment={ALIGN.LEFT} foo="blue">Glenn</TableCell>
     </TableRow>
     <TableRow>
-      <TableCell>2</TableCell>
-      <TableCell>Jack</TableCell>
-      <TableCell>Thompson</TableCell>
+      <TableCell alignment={ALIGN.LEFT}>2</TableCell>
+      <TableCell alignment={ALIGN.LEFT}>Jack</TableCell>
+      <TableCell alignment={ALIGN.LEFT}>Thompson</TableCell>
     </TableRow>
     <TableRow isStriped={true}>
-      <TableCell>3</TableCell>
-      <TableCell>Lianne</TableCell>
-      <TableCell>Michaels</TableCell>
+      <TableCell alignment={ALIGN.LEFT}>3</TableCell>
+      <TableCell alignment={ALIGN.LEFT}>Lianne</TableCell>
+      <TableCell alignment={ALIGN.LEFT}>Michaels</TableCell>
     </TableRow>
     <TableRow>
-      <TableCell>4</TableCell>
-      <TableCell>Gabriela</TableCell>
-      <TableCell>Hines</TableCell>
+      <TableCell alignment={ALIGN.LEFT}>4</TableCell>
+      <TableCell alignment={ALIGN.LEFT}>Gabriela</TableCell>
+      <TableCell alignment={ALIGN.LEFT}>Hines</TableCell>
+    </TableRow>
+  </TableBody>
+</Table>
+```
+
+The following is an example of the `Table` component with the `alignment` prop set to the enum value `ALIGN.CENTER.`
+```jsx
+import {
+  ALIGN,
+  Table,
+  TableCell,
+  TableBody,
+  TableRow,
+  TableHeadingCell,
+  TableHead, 
+} from 'mark-one';
+<Table>
+  <TableHead>
+    <TableRow>
+      <TableHeadingCell scope={'col'}>ID</TableHeadingCell>
+      <TableHeadingCell scope={'col'}>First Name</TableHeadingCell>
+      <TableHeadingCell scope={'col'}>Last Name</TableHeadingCell>
+    </TableRow>
+  </TableHead>
+  <TableBody isScrollable={true}>
+    <TableRow isStriped={true}>
+      <TableCell alignment={ALIGN.CENTER}>1</TableCell>
+      <TableCell alignment={ALIGN.CENTER}>Kristin</TableCell>
+      <TableCell alignment={ALIGN.CENTER}>Glenn</TableCell>
+    </TableRow>
+    <TableRow>
+      <TableCell alignment={ALIGN.CENTER}>2</TableCell>
+      <TableCell alignment={ALIGN.CENTER}>Jack</TableCell>
+      <TableCell alignment={ALIGN.CENTER}>Thompson</TableCell>
     </TableRow>
     <TableRow isStriped={true}>
-      <TableCell>5</TableCell>
-      <TableCell>Cindy</TableCell>
-      <TableCell>Wong</TableCell>
+      <TableCell alignment={ALIGN.CENTER}>3</TableCell>
+      <TableCell alignment={ALIGN.CENTER}>Lianne</TableCell>
+      <TableCell alignment={ALIGN.CENTER}>Michaels</TableCell>
     </TableRow>
     <TableRow>
-      <TableCell>6</TableCell>
-      <TableCell>Alex</TableCell>
-      <TableCell>Rainer</TableCell>
+      <TableCell alignment={ALIGN.CENTER}>4</TableCell>
+      <TableCell alignment={ALIGN.CENTER}>Gabriela</TableCell>
+      <TableCell alignment={ALIGN.CENTER}>Hines</TableCell>
+    </TableRow>
+  </TableBody>
+</Table>
+```
+
+The following is an example of the `Table` component with the `alignment` prop set to the enum value `ALIGN.RIGHT.`
+```jsx
+import {
+  ALIGN,
+  Table,
+  TableCell,
+  TableBody,
+  TableRow,
+  TableHeadingCell,
+  TableHead,
+} from 'mark-one';
+<Table>
+  <TableHead>
+    <TableRow>
+      <TableHeadingCell scope={'col'}>ID</TableHeadingCell>
+      <TableHeadingCell scope={'col'}>First Name</TableHeadingCell>
+      <TableHeadingCell scope={'col'}>Last Name</TableHeadingCell>
+    </TableRow>
+  </TableHead>
+  <TableBody isScrollable={true}>
+    <TableRow isStriped={true}>
+      <TableCell alignment={ALIGN.RIGHT}>1</TableCell>
+      <TableCell alignment={ALIGN.RIGHT}>Kristin</TableCell>
+      <TableCell alignment={ALIGN.RIGHT}>Glenn</TableCell>
+    </TableRow>
+    <TableRow>
+      <TableCell alignment={ALIGN.RIGHT}>2</TableCell>
+      <TableCell alignment={ALIGN.RIGHT}>Jack</TableCell>
+      <TableCell alignment={ALIGN.RIGHT}>Thompson</TableCell>
+    </TableRow>
+    <TableRow isStriped={true}>
+      <TableCell alignment={ALIGN.RIGHT}>3</TableCell>
+      <TableCell alignment={ALIGN.RIGHT}>Lianne</TableCell>
+      <TableCell alignment={ALIGN.RIGHT}>Michaels</TableCell>
+    </TableRow>
+    <TableRow>
+      <TableCell alignment={ALIGN.RIGHT}>4</TableCell>
+      <TableCell alignment={ALIGN.RIGHT}>Gabriela</TableCell>
+      <TableCell alignment={ALIGN.RIGHT}>Hines</TableCell>
     </TableRow>
   </TableBody>
 </Table>

--- a/examples/Tables/Table.md
+++ b/examples/Tables/Table.md
@@ -129,3 +129,47 @@ import {
   </TableBody>
 </Table>
 ```
+
+The following is an example of the `Table` component in which the `alignment` is not set. In this case, the `alignment` property defaults to `ALIGN.LEFT` per our default props.
+```jsx
+import {
+  ALIGN,
+  Table,
+  TableCell,
+  TableBody,
+  TableRow,
+  TableHeadingCell,
+  TableHead,
+} from 'mark-one';
+<Table>
+  <TableHead>
+    <TableRow>
+      <TableHeadingCell scope={'col'}>ID</TableHeadingCell>
+      <TableHeadingCell scope={'col'}>First Name</TableHeadingCell>
+      <TableHeadingCell scope={'col'}>Last Name</TableHeadingCell>
+    </TableRow>
+  </TableHead>
+  <TableBody isScrollable={true}>
+    <TableRow isStriped={true}>
+      <TableCell>1</TableCell>
+      <TableCell>Kristin</TableCell>
+      <TableCell>Glenn</TableCell>
+    </TableRow>
+    <TableRow>
+      <TableCell>2</TableCell>
+      <TableCell>Jack</TableCell>
+      <TableCell>Thompson</TableCell>
+    </TableRow>
+    <TableRow isStriped={true}>
+      <TableCell>3</TableCell>
+      <TableCell>Lianne</TableCell>
+      <TableCell>Michaels</TableCell>
+    </TableRow>
+    <TableRow>
+      <TableCell>4</TableCell>
+      <TableCell>Gabriela</TableCell>
+      <TableCell>Hines</TableCell>
+    </TableRow>
+  </TableBody>
+</Table>
+```

--- a/src/Layout/PageBody.tsx
+++ b/src/Layout/PageBody.tsx
@@ -9,7 +9,9 @@ export interface PageBodyProps {
   theme: BaseTheme;
 }
 
-const PageBody = styled.main<PageBodyProps>``;
+const PageBody = styled.main<PageBodyProps>`
+  margin: ${({ theme }): string => (theme.ws.small)};
+`;
 
 declare type PageBody = ReactElement<PageBodyProps>;
 

--- a/src/Tables/Table.tsx
+++ b/src/Tables/Table.tsx
@@ -14,7 +14,6 @@ export interface TableProps {
 const StyledTable = styled.table`
     border: ${({ theme }): string => (theme.border.light)};
     border-collapse: collapse;
-    margin: ${({ theme }): string => (theme.ws.small)};
     padding: ${({ theme }): string => (theme.ws.xsmall + ' ' + theme.ws.small)};
     width: 100%;
 `;

--- a/src/Tables/TableCell.tsx
+++ b/src/Tables/TableCell.tsx
@@ -17,7 +17,7 @@ export interface TableCellProps {
   /** Text or components to be displayed in the cell */
   children: ReactNode;
   /** Allows you to pass in a alignment property from the ALIGN enum */
-  alignment: ALIGN;
+  alignment?: ALIGN;
 }
 
 const StyledCell = styled.td<TableCellProps>`

--- a/src/Tables/TableCell.tsx
+++ b/src/Tables/TableCell.tsx
@@ -1,30 +1,49 @@
 import React, {
-  FunctionComponent, ReactElement, ReactNode, useContext,
+  FunctionComponent,
+  ReactElement,
+  ReactNode,
+  useContext,
 } from 'react';
 import styled, { ThemeContext } from 'styled-components';
 import { BaseTheme } from '../Theme';
 
+export enum ALIGN {
+  LEFT = 'left',
+  RIGHT = 'right',
+  CENTER = 'center',
+}
+
 export interface TableCellProps {
   /** Text or components to be displayed in the cell */
   children: ReactNode;
+  /** Allows you to pass in a alignment property from the ALIGN enum */
+  alignment: ALIGN;
 }
 
-const StyledCell = styled.td`
+const StyledCell = styled.td<TableCellProps>`
   border-left: ${({ theme }): string => (theme.border.light)};
   border-right: ${({ theme }): string => (theme.border.light)};
   font-family: ${({ theme }): string => (theme.font.data.family)};
   font-size: ${({ theme }): string => (theme.font.data.size)};
   padding: ${({ theme }): string => (theme.ws.xsmall)};
-  text-align: 'center';
+  text-align: ${({ alignment }): string => alignment};
 `;
+
+StyledCell.defaultProps = {
+  alignment: ALIGN.LEFT,
+};
 
 const TableCell: FunctionComponent<TableCellProps> = (props): ReactElement => {
   const {
     children,
+    alignment,
   } = props;
   const theme: BaseTheme = useContext(ThemeContext);
   return (
-    <StyledCell theme={theme}>
+    <StyledCell
+      theme={theme}
+      alignment={alignment}
+    >
       {children}
     </StyledCell>
   );

--- a/src/Tables/TableCell.tsx
+++ b/src/Tables/TableCell.tsx
@@ -7,6 +7,7 @@ import React, {
 import styled, { ThemeContext } from 'styled-components';
 import { BaseTheme } from '../Theme';
 
+/** Represents the possible values for TableCell's text-align property */
 export enum ALIGN {
   LEFT = 'left',
   RIGHT = 'right',

--- a/src/Tables/__tests__/Table.test.tsx
+++ b/src/Tables/__tests__/Table.test.tsx
@@ -26,9 +26,9 @@ describe('Table Components', function () {
         </TableHead>
         <TableBody isScrollable data-testid="tableBody">
           <TableRow isStriped data-testid="firstStripedRow">
-            <TableCell alignment={ALIGN.LEFT}>1</TableCell>
-            <TableCell alignment={ALIGN.LEFT}>Lucy</TableCell>
-            <TableCell alignment={ALIGN.LEFT}>Bernstein</TableCell>
+            <TableCell>1</TableCell>
+            <TableCell>Lucy</TableCell>
+            <TableCell>Bernstein</TableCell>
           </TableRow>
           <TableRow>
             <TableCell alignment={ALIGN.LEFT}>2</TableCell>
@@ -36,14 +36,14 @@ describe('Table Components', function () {
             <TableCell alignment={ALIGN.LEFT}>Win</TableCell>
           </TableRow>
           <TableRow isStriped>
-            <TableCell alignment={ALIGN.LEFT}>3</TableCell>
-            <TableCell alignment={ALIGN.LEFT}>Sam</TableCell>
-            <TableCell alignment={ALIGN.LEFT}>Anderson</TableCell>
+            <TableCell alignment={ALIGN.CENTER}>3</TableCell>
+            <TableCell alignment={ALIGN.CENTER}>Sam</TableCell>
+            <TableCell alignment={ALIGN.CENTER}>Anderson</TableCell>
           </TableRow>
           <TableRow>
-            <TableCell alignment={ALIGN.LEFT}>4</TableCell>
-            <TableCell alignment={ALIGN.LEFT}>Judy</TableCell>
-            <TableCell alignment={ALIGN.LEFT}>Monson</TableCell>
+            <TableCell alignment={ALIGN.RIGHT}>4</TableCell>
+            <TableCell alignment={ALIGN.RIGHT}>Judy</TableCell>
+            <TableCell alignment={ALIGN.RIGHT}>Monson</TableCell>
           </TableRow>
         </TableBody>
       </Table>
@@ -52,6 +52,22 @@ describe('Table Components', function () {
   describe('Table Cell', function () {
     it('contains text', function () {
       getByText('1');
+    });
+    it('defaults to left text-align when alignment prop is unspecified', function () {
+      const style = window.getComputedStyle(getByText('1'));
+      strictEqual(style.textAlign, 'left');
+    });
+    it('has a value of left for text-align when alignment prop is ALIGN.LEFT', function () {
+      const style = window.getComputedStyle(getByText('2'));
+      strictEqual(style.textAlign, 'left');
+    });
+    it('has a value of center for text-align when alignment prop is ALIGN.CENTER', function () {
+      const style = window.getComputedStyle(getByText('3'));
+      strictEqual(style.textAlign, 'center');
+    });
+    it('has a value of right for text-align when alignment prop is ALIGN.RIGHT', function () {
+      const style = window.getComputedStyle(getByText('4'));
+      strictEqual(style.textAlign, 'right');
     });
   });
   describe('Table Heading Cell', function () {

--- a/src/Tables/__tests__/Table.test.tsx
+++ b/src/Tables/__tests__/Table.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render } from 'test-utils';
 import convert from 'color-convert';
 import { strictEqual } from 'assert';
-import TableCell from '../TableCell';
+import TableCell, { ALIGN } from '../TableCell';
 import TableBody from '../TableBody';
 import TableHead from '../TableHead';
 import TableHeadingCell from '../TableHeadingCell';
@@ -26,24 +26,24 @@ describe('Table Components', function () {
         </TableHead>
         <TableBody isScrollable data-testid="tableBody">
           <TableRow isStriped data-testid="firstStripedRow">
-            <TableCell>1</TableCell>
-            <TableCell>Lucy</TableCell>
-            <TableCell>Bernstein</TableCell>
+            <TableCell alignment={ALIGN.LEFT}>1</TableCell>
+            <TableCell alignment={ALIGN.LEFT}>Lucy</TableCell>
+            <TableCell alignment={ALIGN.LEFT}>Bernstein</TableCell>
           </TableRow>
           <TableRow>
-            <TableCell>2</TableCell>
-            <TableCell>Jess</TableCell>
-            <TableCell>Win</TableCell>
+            <TableCell alignment={ALIGN.LEFT}>2</TableCell>
+            <TableCell alignment={ALIGN.LEFT}>Jess</TableCell>
+            <TableCell alignment={ALIGN.LEFT}>Win</TableCell>
           </TableRow>
           <TableRow isStriped>
-            <TableCell>3</TableCell>
-            <TableCell>Sam</TableCell>
-            <TableCell>Anderson</TableCell>
+            <TableCell alignment={ALIGN.LEFT}>3</TableCell>
+            <TableCell alignment={ALIGN.LEFT}>Sam</TableCell>
+            <TableCell alignment={ALIGN.LEFT}>Anderson</TableCell>
           </TableRow>
           <TableRow>
-            <TableCell>4</TableCell>
-            <TableCell>Judy</TableCell>
-            <TableCell>Monson</TableCell>
+            <TableCell alignment={ALIGN.LEFT}>4</TableCell>
+            <TableCell alignment={ALIGN.LEFT}>Judy</TableCell>
+            <TableCell alignment={ALIGN.LEFT}>Monson</TableCell>
           </TableRow>
         </TableBody>
       </Table>
@@ -90,10 +90,10 @@ describe('Table Components', function () {
           </TableHead>
           <TableBody isScrollable={false} data-testid="tbody">
             <TableRow>
-              <TableCell>1</TableCell>
+              <TableCell alignment={ALIGN.RIGHT}>1</TableCell>
             </TableRow>
             <TableRow>
-              <TableCell>3</TableCell>
+              <TableCell alignment={ALIGN.RIGHT}>3</TableCell>
             </TableRow>
           </TableBody>
         </Table>
@@ -111,10 +111,10 @@ describe('Table Components', function () {
           </TableHead>
           <TableBody data-testid="tbody">
             <TableRow>
-              <TableCell>2</TableCell>
+              <TableCell alignment={ALIGN.LEFT}>2</TableCell>
             </TableRow>
             <TableRow>
-              <TableCell>4</TableCell>
+              <TableCell alignment={ALIGN.LEFT}>4</TableCell>
             </TableRow>
           </TableBody>
         </Table>

--- a/src/Tables/index.ts
+++ b/src/Tables/index.ts
@@ -1,5 +1,5 @@
 export { default as Table } from './Table';
-export { default as TableCell } from './TableCell';
+export { default as TableCell, ALIGN } from './TableCell';
 export { default as TableRow } from './TableRow';
 export { default as TableHead } from './TableHead';
 export { default as TableHeadingCell } from './TableHeadingCell';


### PR DESCRIPTION
This PR removes the margin around the `Table` component, since the margin was causing a horizontal scrollbar to appear in Course Planning. The margin was moved to the `PageBody` component instead. Also, the prop `alignment` was added to the `TableCell` component so that users can adjust how the content within the `td` is positioned (`text-align` is set to `left`, `right`, or `center`). The default value of the `alignment` prop is `left`.

## Types of changes
<!--
  What types of changes does your code introduce? Put an `x` in all the boxes
  that apply:
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
<!--
  Go over all the following points, and put an `x` in all the boxes that apply.
-->
- [x] I have run `eslint` on the code
- [x] I have added JSDoc for all of my code (where applicable)
- [ ] I have added tests to cover my changes.

## Priority:
- [x] Normal <!-- New piece of functionality -->
- [ ] High <!-- Critical bug requiring urgent review -->

## Related Issues:
<!--
  Add the issue number in below that this PR is intended to address.

  Also mention any issues that this PR is related to, and if possible,
  provide more information regarding the relationship to the issues in
  question (i.e does the PR fix the issue, is it designed to fix another bug
  that is similar to the issue etc.)
-->
Addresses [#117](https://github.com/seas-computing/course-planner/issues/117)

<!--
  Attribution:
  PR Template adapted from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->