### PR TITLE
Fix Typing for TableCell backgroundColor prop

### DIFF
--- a/src/Theme/MarkOneTheme.ts
+++ b/src/Theme/MarkOneTheme.ts
@@ -19,7 +19,7 @@ export interface BaseTheme extends DefaultTheme {
   color?: {
     background?: ColorRange;
     text?: ColorRange;
-    area?: ColorRange;
+    area?: { [key: string]: string };
   };
   font?: {
     [key: string]: FontSpec;


### PR DESCRIPTION
This PR addresses this error in the `Course Planning` app: 
![image](https://user-images.githubusercontent.com/29589689/76024183-a7e62680-5ef8-11ea-8845-626cf341cf86.png)


Individual areas cannot be accessed without casting using `ColorRange`, which was a broader type than required. Instead of `ColorRange` as a type, I set the type for `area` to `{ [key: string]: string };`

## Types of changes
<!--
  What types of changes does your code introduce? Put an `x` in all the boxes
  that apply:
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
<!--
  Go over all the following points, and put an `x` in all the boxes that apply.
-->
- [x] I have run `eslint` on the code
- [x] I have added JSDoc for all of my code (where applicable)
- [ ] I have added tests to cover my changes.

## Priority:
- [x] Normal <!-- New piece of functionality -->
- [ ] High <!-- Critical bug requiring urgent review -->

## Related Issues:
<!--
  Add the issue number in below that this PR is intended to address.

  Also mention any issues that this PR is related to, and if possible,
  provide more information regarding the relationship to the issues in
  question (i.e does the PR fix the issue, is it designed to fix another bug
  that is similar to the issue etc.)
-->
Addresses [#117](https://github.com/seas-computing/course-planner/issues/117)

<!--
  Attribution:
  PR Template adapted from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->