### PR TITLE
Add missing course prefix

### DIFF
--- a/src/Theme/MarkOneTheme.ts
+++ b/src/Theme/MarkOneTheme.ts
@@ -108,7 +108,7 @@ const MarkOneTheme: BaseTheme = {
       ee: '#f9df57',
       ese: '#75c3d5',
       general: '#95b5df',
-      matme: '#b18cbb',
+      'mat & me': '#b18cbb',
       mde: '#c0c0c0',
       msmba: '#946eb7',
       sem: '#ec8f9c',


### PR DESCRIPTION
The `backgroundColor` was not mapped correctly for `mat & me.` The course prefix `mat & me` was missing as a course prefix in the `area` object. Originally, it was listed as `matme` in the `area` object.
![image](https://user-images.githubusercontent.com/29589689/76026699-4d9b9480-5efd-11ea-9244-1ba7b158e557.png)

## Types of changes
<!--
  What types of changes does your code introduce? Put an `x` in all the boxes
  that apply:
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
<!--
  Go over all the following points, and put an `x` in all the boxes that apply.
-->
- [x] I have run `eslint` on the code
- [x] I have added JSDoc for all of my code (where applicable)
- [ ] I have added tests to cover my changes.

## Priority:
- [x] Normal <!-- New piece of functionality -->
- [ ] High <!-- Critical bug requiring urgent review -->

## Related Issues:
<!--
  Add the issue number in below that this PR is intended to address.

  Also mention any issues that this PR is related to, and if possible,
  provide more information regarding the relationship to the issues in
  question (i.e does the PR fix the issue, is it designed to fix another bug
  that is similar to the issue etc.)
-->
Addresses [#117](https://github.com/seas-computing/course-planner/issues/117)

<!--
  Attribution:
  PR Template adapted from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->