### PR TITLE
Adjust Header component to work better with PageTitle

### DIFF
--- a/src/Layout/Header.tsx
+++ b/src/Layout/Header.tsx
@@ -24,7 +24,7 @@ export interface HeaderProps {
  */
 
 const Header = styled.header<HeaderProps>`
-  align-items: flex-end;
+  align-items: baseline;
   background-color: ${({ background }): string => background};
   display: flex;
   justify-content: ${({ justify }): string => justify};


### PR DESCRIPTION
A small tweak to the `Header` component to make it work better with `PageTitle` by re-aligning child components using `align-items: baseline;`. This, in turn means that things are vertically center aligned, rather than aligned to the bottom of the header.

Before:  
![image](https://user-images.githubusercontent.com/50675045/76437800-7c4bbc00-6390-11ea-8cf9-55ef9dcb35e3.png)  
![image](https://user-images.githubusercontent.com/50675045/76438008-cc2a8300-6390-11ea-83b3-e9ac25d8eef0.png)



After:  
![image](https://user-images.githubusercontent.com/50675045/76437904-a4d3b600-6390-11ea-866b-10fb8c388eef.png)  
![image](https://user-images.githubusercontent.com/50675045/76437946-b5842c00-6390-11ea-8996-b8e40f3a6ea5.png)
