### PR TITLE
Modal Footer

### DIFF
--- a/examples/Modals/Modal.md
+++ b/examples/Modals/Modal.md
@@ -6,7 +6,7 @@ The `isVisible` prop will be used by the parent component to control whether or 
 
 ```jsx
 import { useState } from 'react';
-import { Button } from 'mark-one';
+import { Button, ModalFooter } from 'mark-one';
 
 const TestModal = () => {
   const [modalVisible, setModalVisible] = useState(false);
@@ -20,9 +20,11 @@ const TestModal = () => {
         isVisible={modalVisible}
       >
         <div>This can be any arbitrary content</div>
-        <Button onClick={() => setModalVisible(false)}>
-          Close Modal
-        </Button>
+        <ModalFooter>
+          <Button onClick={() => setModalVisible(false)}>
+            Close Modal
+          </Button>
+        </ModalFooter>
       </Modal>
     </div>
   );
@@ -37,7 +39,7 @@ You can also pass in onOpen and onClose handlers that will be called when the mo
 
 ```jsx
 import { useState } from 'react';
-import { Button, TextInput } from 'mark-one';
+import { Button, TextInput, ModalFooter } from 'mark-one';
 
 const TestModal = () => {
   const [modalCount, setModalCount] = useState(0);
@@ -67,10 +69,12 @@ const TestModal = () => {
               }} 
             />
           </div>
+        </div>
+        <ModalFooter>
           <Button onClick={() => setModalVisible(false)}>
             Close Modal
           </Button>
-        </div>
+        </ModalFooter>
       </Modal>
       <p>
         <strong>

--- a/examples/Modals/ModalFooter.md
+++ b/examples/Modals/ModalFooter.md
@@ -1,0 +1,40 @@
+This is a utility component for adding a footer row to the `<Modal>`. It's set up to use `flexbox`, and fill in buttons from right to left. For example:
+
+```jsx
+import { useState } from 'react';
+import { Button } from 'mark-one';
+import Modal from '../../src/Modals/Modal.tsx';
+
+const TestModal = () => {
+  const [modalVisible, setModalVisible] = useState(false);
+  return (
+    <div>
+      <Button onClick={() => {setModalVisible(true)}}>
+        Open Modal
+      </Button>
+      <Modal
+        closeHandler={() => {setModalVisible(false)}}
+        isVisible={modalVisible}
+      >
+        <div>
+          This can be any arbitrary content
+        </div>
+        <ModalFooter>
+          <Button onClick={() => setModalVisible(false)}>
+            One
+          </Button>
+          <Button onClick={() => setModalVisible(false)}>
+            Two
+          </Button>
+          <Button onClick={() => setModalVisible(false)}>
+            Three
+          </Button>
+        </ModalFooter>
+      </Modal>
+    </div>
+  );
+}
+
+<TestModal />
+```
+

--- a/src/Modals/ModalFooter.tsx
+++ b/src/Modals/ModalFooter.tsx
@@ -1,0 +1,30 @@
+import { ReactElement, ReactNode } from 'react';
+import styled, { withTheme } from 'styled-components';
+
+interface ModalFooterProps {
+  /**
+   * the content of the Modal Footer
+   */
+  children: ReactNode;
+}
+
+
+const styledModalFooter = styled.div<ModalFooterProps>`
+  background-color: ${({ theme }): string => (theme.color.background.subtle)};
+  border-top: ${({ theme }): string => (theme.border.light)};
+  display: flex;
+  flex-direction: reverse-row;
+  justify-content: space-between;
+  padding: ${({ theme }): string => `${theme.ws.small} ${theme.ws.medium}`};
+  width: 100%;
+`;
+
+declare type ModalFooter = ReactElement<ModalFooterProps>;
+
+/**
+ * @component ModalFooter
+ * Used within the [[Modal]] component to render a separated bottom section,
+ * typically containing buttons for save, cancel, etc.
+ */
+export const ModalFooter = withTheme(styledModalFooter);
+export default ModalFooter;

--- a/src/Modals/ModalFooter.tsx
+++ b/src/Modals/ModalFooter.tsx
@@ -10,8 +10,6 @@ interface ModalFooterProps {
 
 
 const styledModalFooter = styled.div<ModalFooterProps>`
-  background-color: ${({ theme }): string => (theme.color.background.subtle)};
-  border-top: ${({ theme }): string => (theme.border.light)};
   display: flex;
   flex-direction: reverse-row;
   justify-content: space-between;

--- a/src/Modals/ModalFooter.tsx
+++ b/src/Modals/ModalFooter.tsx
@@ -11,7 +11,7 @@ interface ModalFooterProps {
 
 const styledModalFooter = styled.div<ModalFooterProps>`
   display: flex;
-  flex-direction: reverse-row;
+  flex-direction: row-reverse;
   justify-content: space-between;
   padding: ${({ theme }): string => `${theme.ws.small} ${theme.ws.medium}`};
   width: 100%;

--- a/src/Modals/index.ts
+++ b/src/Modals/index.ts
@@ -1,1 +1,2 @@
 export * from './Modal';
+export * from './ModalFooter';


### PR DESCRIPTION
Adds a Modal Footer component to the library, and integrates it into the Examples for the modal. Since the `ModalFooter` is just a `styled-component` wrapped in `withTheme`, I haven't added any tests for the component -- any tests would just be verifying that third-party libraries do what they're supposed to, and I don't think that's necessary for our needs. Happy to discuss further if you feel differently.