### PR TITLE
Change import paths to be relative

### DIFF
--- a/src/Modals/ModalBody.tsx
+++ b/src/Modals/ModalBody.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react';
 import styled, { withTheme } from 'styled-components';
-import { BaseTheme } from 'Theme';
+import { BaseTheme } from '../Theme';
 
 interface ModalBodyProps {
   /**

--- a/src/Modals/ModalHeader.tsx
+++ b/src/Modals/ModalHeader.tsx
@@ -5,11 +5,11 @@ import React, {
   useContext,
 } from 'react';
 import styled, { ThemeContext } from 'styled-components';
-import { BorderlessButton } from 'Buttons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faTimes } from '@fortawesome/free-solid-svg-icons';
-import { VARIANT, BaseTheme } from 'Theme';
-import { SectionHeading } from 'Headings';
+import { BorderlessButton } from '../Buttons';
+import { VARIANT, BaseTheme } from '../Theme';
+import { SectionHeading } from '../Headings';
 
 interface ModalHeaderProps {
   /**


### PR DESCRIPTION
Something weird happened with my auto-importing and those modules were loaded from the non-relative paths. I'm not sure why it did that and honestly I'm a little surprised it even worked in the mark-one stuff. I'll need to look into that and potentially see if that's something that CI could catch for us.

fixes seas-computing/course-planner#191