### PR TITLE
Update table components

### DIFF
--- a/examples/Tables/Table.md
+++ b/examples/Tables/Table.md
@@ -173,3 +173,96 @@ import {
   </TableBody>
 </Table>
 ```
+
+### More Complex Layouts
+
+Some tables may require more complex layouts, such as cells that span multiple columns/rows or layered, hierarchical headers. For example:
+
+```tsx
+import {
+  ALIGN,
+  Table,
+  TableCell,
+  TableBody,
+  TableRow,
+  TableRowHeadingCell,
+  TableHeadingCell,
+  TableHeadingSpacer,
+  TableHead,
+} from 'mark-one';
+
+<Table>
+  <col />
+  <colgroup span="4" />
+  <colgroup span="4" />
+  <TableHead>
+    <TableRow noHighlight>
+      <TableHeadingSpacer />
+      <TableHeadingCell
+        backgroundColor="transparent"
+        colSpan="4"
+        scope="colgroup"
+      >
+        Fall 2019
+      </TableHeadingCell>
+      <TableHeadingCell
+        backgroundColor="transparent"
+        colSpan="4"
+        scope="colgroup"
+      >
+        Spring 2020
+      </TableHeadingCell>
+    </TableRow>
+    <TableRow>
+      <TableHeadingCell scope="col" rowSpan="2">Course</TableHeadingCell>
+      <TableHeadingCell scope="col" rowSpan="2">Offered</TableHeadingCell>
+      <TableHeadingCell colSpan="3">Enrollment</TableHeadingCell>
+      <TableHeadingCell scope="col" rowSpan="2">Offered</TableHeadingCell>
+      <TableHeadingCell colSpan="3">Enrollment</TableHeadingCell>
+    </TableRow>
+    <TableRow>
+      <TableHeadingCell scope="col">Pre</TableHeadingCell>
+      <TableHeadingCell scope="col">Study</TableHeadingCell>
+      <TableHeadingCell scope="col">Actual</TableHeadingCell>
+      <TableHeadingCell scope="col">Pre</TableHeadingCell>
+      <TableHeadingCell scope="col">Study</TableHeadingCell>
+      <TableHeadingCell scope="col">Actual</TableHeadingCell>
+    </TableRow>
+  </TableHead>
+  <TableBody>
+    <TableRow>
+      <TableRowHeadingCell scope="row">CS 50</TableRowHeadingCell>
+      <TableCell>YES</TableCell>
+      <TableCell>600</TableCell>
+      <TableCell>480</TableCell>
+      <TableCell>300</TableCell>
+      <TableCell>NO</TableCell>
+      <TableCell />
+      <TableCell />
+      <TableCell />
+    </TableRow>
+    <TableRow isStriped>
+      <TableRowHeadingCell scope="row">CS 51</TableRowHeadingCell>
+      <TableCell>NO</TableCell>
+      <TableCell />
+      <TableCell />
+      <TableCell />
+      <TableCell>YES</TableCell>
+      <TableCell>185</TableCell>
+      <TableCell>140</TableCell>
+      <TableCell>120</TableCell>
+    </TableRow>
+    <TableRow>
+      <TableRowHeadingCell scope="row">ES 100</TableRowHeadingCell>
+      <TableCell>YES</TableCell>
+      <TableCell>250</TableCell>
+      <TableCell>175</TableCell>
+      <TableCell>80</TableCell>
+      <TableCell>YES</TableCell>
+      <TableCell>300</TableCell>
+      <TableCell>150</TableCell>
+      <TableCell>100</TableCell>
+    </TableRow>
+  </TableBody>
+</Table>
+```

--- a/src/Tables/Table.tsx
+++ b/src/Tables/Table.tsx
@@ -1,5 +1,6 @@
 import styled, { withTheme } from 'styled-components';
 import { BaseTheme } from 'Theme';
+import { ReactElement } from 'react';
 import TableHead from './TableHead';
 import TableBody from './TableBody';
 
@@ -8,7 +9,7 @@ export interface TableProps {
   * Internal table components like <thead>, <tbody>, <col>. and <colgroup>
   * including their respective child components
   */
-  children: Array<typeof TableHead | typeof TableBody | HTMLTableColElement>;
+  children: Array<TableHead | TableBody | HTMLTableColElement>;
   /** The application theme */
   theme: BaseTheme;
 }
@@ -25,5 +26,7 @@ const StyledTable = styled.table`
  */
 
 const Table = withTheme(StyledTable);
+
+declare type Table = ReactElement<TableProps>;
 
 export default Table;

--- a/src/Tables/Table.tsx
+++ b/src/Tables/Table.tsx
@@ -1,10 +1,7 @@
-import React, {
-  FunctionComponent, ReactElement, useContext,
-} from 'react';
-import styled, { ThemeContext } from 'styled-components';
-import { BaseTheme } from '../Theme';
+import styled, { withTheme } from 'styled-components';
+import { BaseTheme } from 'Theme';
 import TableHead from './TableHead';
-import { TableBody } from './TableBody';
+import TableBody from './TableBody';
 
 export interface TableProps {
   /**
@@ -22,16 +19,11 @@ const StyledTable = styled.table`
     width: 100%;
 `;
 
-const Table: FunctionComponent<TableProps> = (props): ReactElement => {
-  const {
-    children,
-  } = props;
-  const theme: BaseTheme = useContext(ThemeContext);
-  return (
-    <StyledTable theme={theme}>
-      {children}
-    </StyledTable>
-  );
-};
+/**
+ * @component
+ * Renders a simple, full-width <table>
+ */
+
+const Table = withTheme(StyledTable);
 
 export default Table;

--- a/src/Tables/Table.tsx
+++ b/src/Tables/Table.tsx
@@ -12,7 +12,6 @@ export interface TableProps {
 }
 
 const StyledTable = styled.table`
-    border: ${({ theme }): string => (theme.border.light)};
     border-collapse: collapse;
     padding: ${({ theme }): string => (theme.ws.xsmall + ' ' + theme.ws.small)};
     width: 100%;

--- a/src/Tables/Table.tsx
+++ b/src/Tables/Table.tsx
@@ -1,6 +1,6 @@
 import styled, { withTheme } from 'styled-components';
 import { BaseTheme } from 'Theme';
-import { ReactElement } from 'react';
+import { ReactElement, ForwardRefExoticComponent } from 'react';
 import TableHead from './TableHead';
 import TableBody from './TableBody';
 
@@ -9,9 +9,10 @@ export interface TableProps {
   * Internal table components like <thead>, <tbody>, <col>. and <colgroup>
   * including their respective child components
   */
-  children: Array<TableHead | TableBody | HTMLTableColElement>;
+  children: (TableHead | TableBody | HTMLTableColElement)
+  | (TableHead | TableBody | HTMLTableColElement)[];
   /** The application theme */
-  theme: BaseTheme;
+  theme?: BaseTheme;
 }
 
 const StyledTable = styled.table`
@@ -25,7 +26,7 @@ const StyledTable = styled.table`
  * Renders a simple, full-width <table>
  */
 
-const Table = withTheme(StyledTable);
+const Table: ForwardRefExoticComponent<TableProps> = withTheme(StyledTable);
 
 declare type Table = ReactElement<TableProps>;
 

--- a/src/Tables/Table.tsx
+++ b/src/Tables/Table.tsx
@@ -7,8 +7,13 @@ import TableHead from './TableHead';
 import { TableBody } from './TableBody';
 
 export interface TableProps {
-  /** Internal table components like <thead> and <tbody> including their respective child components */
-  children: Array<TableHead | TableBody>;
+  /**
+  * Internal table components like <thead>, <tbody>, <col>. and <colgroup>
+  * including their respective child components
+  */
+  children: Array<typeof TableHead | typeof TableBody | HTMLTableColElement>;
+  /** The application theme */
+  theme: BaseTheme;
 }
 
 const StyledTable = styled.table`

--- a/src/Tables/TableBody.tsx
+++ b/src/Tables/TableBody.tsx
@@ -13,7 +13,8 @@ export interface TableBodyProps {
   isScrollable?: boolean;
 }
 
-const TableBody = styled.tbody<TableBodyProps>`
+const StyledTableBody = styled.tbody<TableBodyProps>`
+  border: ${({ theme }): string => (theme.border.light)};
   overflow: ${({ isScrollable }): string => (isScrollable ? 'scroll' : 'visible')};
 `;
 

--- a/src/Tables/TableBody.tsx
+++ b/src/Tables/TableBody.tsx
@@ -1,6 +1,7 @@
+import { ReactElement } from 'react';
 import styled, { withTheme } from 'styled-components';
 import { BaseTheme } from 'Theme';
-import { TableRow } from './TableRow';
+import TableRow from './TableRow';
 
 export interface TableBodyProps {
   /** Our TableRow functional component serves as the children for TableBody */
@@ -27,5 +28,7 @@ const TableBody = withTheme(StyledTableBody);
 TableBody.defaultProps = {
   isScrollable: false,
 };
+
+declare type TableBody = ReactElement<TableBodyProps>;
 
 export default TableBody;

--- a/src/Tables/TableBody.tsx
+++ b/src/Tables/TableBody.tsx
@@ -1,17 +1,17 @@
-import { ReactElement } from 'react';
+import { ReactElement, ForwardRefExoticComponent } from 'react';
 import styled, { withTheme } from 'styled-components';
 import { BaseTheme } from 'Theme';
 import TableRow from './TableRow';
 
 export interface TableBodyProps {
   /** Our TableRow functional component serves as the children for TableBody */
-  children: TableRow[];
+  children: TableRow | TableRow[];
   /** Controls whether to add a scrollbar in the case where the content of the
    * body does not fit within the table body
    */
   isScrollable?: boolean;
   /** The application theme */
-  theme: BaseTheme;
+  theme?: BaseTheme;
 }
 
 const StyledTableBody = styled.tbody<TableBodyProps>`
@@ -23,7 +23,9 @@ const StyledTableBody = styled.tbody<TableBodyProps>`
  * @component
  * Renders a <tbody> component for use inside the <Table> component.
  */
-const TableBody = withTheme(StyledTableBody);
+const TableBody: ForwardRefExoticComponent<
+TableBodyProps
+> = withTheme(StyledTableBody);
 
 TableBody.defaultProps = {
   isScrollable: false,

--- a/src/Tables/TableBody.tsx
+++ b/src/Tables/TableBody.tsx
@@ -1,7 +1,5 @@
-import {
-  ReactElement,
-} from 'react';
 import styled, { withTheme } from 'styled-components';
+import { BaseTheme } from 'Theme';
 import { TableRow } from './TableRow';
 
 export interface TableBodyProps {
@@ -11,6 +9,8 @@ export interface TableBodyProps {
    * body does not fit within the table body
    */
   isScrollable?: boolean;
+  /** The application theme */
+  theme: BaseTheme;
 }
 
 const StyledTableBody = styled.tbody<TableBodyProps>`
@@ -18,10 +18,14 @@ const StyledTableBody = styled.tbody<TableBodyProps>`
   overflow: ${({ isScrollable }): string => (isScrollable ? 'scroll' : 'visible')};
 `;
 
+/**
+ * @component
+ * Renders a <tbody> component for use inside the <Table> component.
+ */
+const TableBody = withTheme(StyledTableBody);
+
 TableBody.defaultProps = {
   isScrollable: false,
 };
 
-export type TableBody = ReactElement<TableBodyProps>;
-
-export default withTheme(TableBody);
+export default TableBody;

--- a/src/Tables/TableCell.tsx
+++ b/src/Tables/TableCell.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, ReactElement } from 'react';
+import { ReactNode, ReactElement, ForwardRefExoticComponent } from 'react';
 import styled, { withTheme } from 'styled-components';
 import { BaseTheme } from 'Theme';
 
@@ -12,7 +12,7 @@ export enum ALIGN {
 export interface TableCellProps {
   /**
    * Allows you to pass in a alignment property from the ALIGN enum.
-   * Defaults to LEFT
+   * Defaults to ALIGN.LEFT
    */
   alignment?: ALIGN;
   /** Specifies the background color of the table cell */
@@ -20,7 +20,7 @@ export interface TableCellProps {
   /** Text or components to be displayed in the cell */
   children: ReactNode;
   /** The application theme */
-  theme: BaseTheme;
+  theme?: BaseTheme;
 }
 
 const StyledCell = styled.td<TableCellProps>`
@@ -41,8 +41,8 @@ StyledCell.defaultProps = {
  * @component
  * Renders a single <td> element, for use inside of a <TableRow>
  */
-
-const TableCell = withTheme(StyledCell);
+const TableCell:
+ForwardRefExoticComponent<TableCellProps> = withTheme(StyledCell);
 
 declare type TableCell = ReactElement<TableCellProps>;
 

--- a/src/Tables/TableCell.tsx
+++ b/src/Tables/TableCell.tsx
@@ -1,11 +1,8 @@
-import React, {
-  FunctionComponent,
-  ReactElement,
+import {
   ReactNode,
-  useContext,
 } from 'react';
-import styled, { ThemeContext } from 'styled-components';
-import { BaseTheme } from '../Theme';
+import styled, { withTheme } from 'styled-components';
+import { BaseTheme } from 'Theme';
 
 /** Represents the possible values for TableCell's text-align property */
 export enum ALIGN {
@@ -15,12 +12,17 @@ export enum ALIGN {
 }
 
 export interface TableCellProps {
-  /** Text or components to be displayed in the cell */
-  children: ReactNode;
-  /** Allows you to pass in a alignment property from the ALIGN enum */
+  /**
+   * Allows you to pass in a alignment property from the ALIGN enum.
+   * Defaults to LEFT
+   */
   alignment?: ALIGN;
   /** Specifies the background color of the table cell */
   backgroundColor?: string;
+  /** Text or components to be displayed in the cell */
+  children: ReactNode;
+  /** The application theme */
+  theme: BaseTheme;
 }
 
 const StyledCell = styled.td<TableCellProps>`
@@ -37,22 +39,11 @@ StyledCell.defaultProps = {
   alignment: ALIGN.LEFT,
 };
 
-const TableCell: FunctionComponent<TableCellProps> = (props): ReactElement => {
-  const {
-    children,
-    alignment,
-    backgroundColor,
-  } = props;
-  const theme: BaseTheme = useContext(ThemeContext);
-  return (
-    <StyledCell
-      theme={theme}
-      alignment={alignment}
-      backgroundColor={backgroundColor}
-    >
-      {children}
-    </StyledCell>
-  );
-};
+/**
+ * @component
+ * Renders a single <td> element, for use inside of a <TableRow>
+ */
+
+const TableCell = withTheme(StyledCell);
 
 export default TableCell;

--- a/src/Tables/TableCell.tsx
+++ b/src/Tables/TableCell.tsx
@@ -1,6 +1,4 @@
-import {
-  ReactNode,
-} from 'react';
+import { ReactNode, ReactElement } from 'react';
 import styled, { withTheme } from 'styled-components';
 import { BaseTheme } from 'Theme';
 
@@ -45,5 +43,7 @@ StyledCell.defaultProps = {
  */
 
 const TableCell = withTheme(StyledCell);
+
+declare type TableCell = ReactElement<TableCellProps>;
 
 export default TableCell;

--- a/src/Tables/TableHead.tsx
+++ b/src/Tables/TableHead.tsx
@@ -1,8 +1,5 @@
-import React, {
-  FunctionComponent, ReactElement, useContext,
-} from 'react';
-import styled, { ThemeContext } from 'styled-components';
-import { BaseTheme } from '../Theme';
+import styled, { withTheme } from 'styled-components';
+import { BaseTheme } from 'Theme';
 import { TableRow } from './TableRow';
 
 export interface TableHeadProps {
@@ -16,18 +13,11 @@ const StyledTableHead = styled.thead`
   background-color: ${({ theme }): string => (theme.color.background.medium)};
 `;
 
-const TableHead: FunctionComponent<TableHeadProps> = (props): ReactElement => {
-  const {
-    children,
-  } = props;
-  const theme: BaseTheme = useContext(ThemeContext);
-  return (
-    <StyledTableHead theme={theme}>
-      {children}
-    </StyledTableHead>
-  );
-};
+/**
+ * @component
+ * Renders a <thead> component to be used inside of a <Table>
+ */
 
-declare type TableHead = ReactElement<TableHeadProps>;
+const TableHead = withTheme(StyledTableHead);
 
 export default TableHead;

--- a/src/Tables/TableHead.tsx
+++ b/src/Tables/TableHead.tsx
@@ -1,13 +1,13 @@
 import styled, { withTheme } from 'styled-components';
 import { BaseTheme } from 'Theme';
-import { ReactElement } from 'react';
+import { ReactElement, ForwardRefExoticComponent } from 'react';
 import TableRow from './TableRow';
 
 export interface TableHeadProps {
   /** Our TableRow functional component serves as the children for TableHead */
   children: TableRow | TableRow[];
   /** The application theme */
-  theme: BaseTheme;
+  theme?: BaseTheme;
 }
 
 const StyledTableHead = styled.thead`
@@ -19,7 +19,8 @@ const StyledTableHead = styled.thead`
  * Renders a <thead> component to be used inside of a <Table>
  */
 
-const TableHead = withTheme(StyledTableHead);
+const TableHead:
+ForwardRefExoticComponent<TableHeadProps> = withTheme(StyledTableHead);
 
 declare type TableHead = ReactElement<TableHeadProps>;
 

--- a/src/Tables/TableHead.tsx
+++ b/src/Tables/TableHead.tsx
@@ -1,6 +1,7 @@
 import styled, { withTheme } from 'styled-components';
 import { BaseTheme } from 'Theme';
-import { TableRow } from './TableRow';
+import { ReactElement } from 'react';
+import TableRow from './TableRow';
 
 export interface TableHeadProps {
   /** Our TableRow functional component serves as the children for TableHead */
@@ -19,5 +20,7 @@ const StyledTableHead = styled.thead`
  */
 
 const TableHead = withTheme(StyledTableHead);
+
+declare type TableHead = ReactElement<TableHeadProps>;
 
 export default TableHead;

--- a/src/Tables/TableHead.tsx
+++ b/src/Tables/TableHead.tsx
@@ -7,7 +7,9 @@ import { TableRow } from './TableRow';
 
 export interface TableHeadProps {
   /** Our TableRow functional component serves as the children for TableHead */
-  children: TableRow;
+  children: TableRow | TableRow[];
+  /** The application theme */
+  theme: BaseTheme;
 }
 
 const StyledTableHead = styled.thead`

--- a/src/Tables/TableHeadingCell.tsx
+++ b/src/Tables/TableHeadingCell.tsx
@@ -2,8 +2,10 @@ import {
   MouseEventHandler,
   ReactNode,
   ReactElement,
+  ForwardRefExoticComponent,
 } from 'react';
 import styled, { withTheme } from 'styled-components';
+import { BaseTheme } from 'Theme';
 
 export interface TableHeadingCellProps {
   /** Specifies the background color of the table cell */
@@ -17,7 +19,9 @@ export interface TableHeadingCellProps {
   /** Handles cells that span multiple rows */
   rowSpan?: number;
   /** Specifies the group of cells that the table heading refers to */
-  scope: 'col' | 'colgroup' | 'auto';
+  scope?: 'col' | 'colgroup' | 'auto';
+  /** The application theme */
+  theme?: BaseTheme;
 }
 
 const StyledTableHeadingCell = styled.th<TableHeadingCellProps>`
@@ -36,7 +40,9 @@ const StyledTableHeadingCell = styled.th<TableHeadingCellProps>`
  * row heading components.
  */
 
-const TableHeadingCell = withTheme(StyledTableHeadingCell);
+const TableHeadingCell: ForwardRefExoticComponent<
+TableHeadingCellProps
+> = withTheme(StyledTableHeadingCell);
 
 declare type TableHeadingCell = ReactElement<TableHeadingCellProps>;
 

--- a/src/Tables/TableHeadingCell.tsx
+++ b/src/Tables/TableHeadingCell.tsx
@@ -1,8 +1,8 @@
-import React, {
-  FunctionComponent, MouseEventHandler, ReactElement, ReactNode, useContext,
+import {
+  MouseEventHandler,
+  ReactNode,
 } from 'react';
-import styled, { ThemeContext } from 'styled-components';
-import { BaseTheme } from '../Theme';
+import styled, { withTheme } from 'styled-components';
 
 export interface TableHeadingCellProps {
   /** Specifies the background color of the table cell */
@@ -27,25 +27,14 @@ const StyledTableHeadingCell = styled.th<TableHeadingCellProps>`
   font-weight: ${({ theme }): string => (theme.font.bold.weight)};
   text-align: 'center';
 `;
-const TableHeadingCell: FunctionComponent<TableHeadingCellProps> = (props):
-ReactElement => {
-  const {
-    children,
-    clickHandler,
-    scope,
-  } = props;
-  const theme: BaseTheme = useContext(ThemeContext);
-  return (
-    <StyledTableHeadingCell
-      onClick={clickHandler}
-      theme={theme}
-      scope={scope}
-    >
-      {children}
-    </StyledTableHeadingCell>
-  );
-};
 
-declare type TableHeadingCell = ReactElement<TableHeadingCellProps>;
+/**
+ * @component
+ * Used to render a single cell within the TableHead section on a table.
+ * Inteded for column headers only; There is also a TableRowHeadingCell for
+ * row heading components.
+ */
+
+const TableHeadingCell = withTheme(StyledTableHeadingCell);
 
 export default TableHeadingCell;

--- a/src/Tables/TableHeadingCell.tsx
+++ b/src/Tables/TableHeadingCell.tsx
@@ -11,8 +11,12 @@ export interface TableHeadingCellProps {
   children: ReactNode;
   /** Function to call on click event */
   clickHandler?: MouseEventHandler;
+  /** Handles cells that span multiple columns */
+  colSpan?: number;
+  /** Handles cells that span multiple rows */
+  rowSpan?: number;
   /** Specifies the group of cells that the table heading refers to */
-  scope: 'row' | 'col' | 'rowgroup' | 'colgroup' | 'auto';
+  scope: 'col' | 'colgroup' | 'auto';
 }
 
 const StyledTableHeadingCell = styled.th<TableHeadingCellProps>`

--- a/src/Tables/TableHeadingCell.tsx
+++ b/src/Tables/TableHeadingCell.tsx
@@ -5,6 +5,8 @@ import styled, { ThemeContext } from 'styled-components';
 import { BaseTheme } from '../Theme';
 
 export interface TableHeadingCellProps {
+  /** Specifies the background color of the table cell */
+  backgroundColor?: string;
   /** Text or components to be displayed in the table heading cell */
   children: ReactNode;
   /** Function to call on click event */
@@ -13,7 +15,10 @@ export interface TableHeadingCellProps {
   scope: 'row' | 'col' | 'rowgroup' | 'colgroup' | 'auto';
 }
 
-const StyledTableHeadingCell = styled.th`
+const StyledTableHeadingCell = styled.th<TableHeadingCellProps>`
+  background-color: ${({ theme, backgroundColor }): string => (
+    backgroundColor || theme.color.background.medium
+  )};
   border: ${({ theme }): string => (theme.border.light)};
   font-weight: ${({ theme }): string => (theme.font.bold.weight)};
   text-align: 'center';

--- a/src/Tables/TableHeadingCell.tsx
+++ b/src/Tables/TableHeadingCell.tsx
@@ -1,6 +1,7 @@
 import {
   MouseEventHandler,
   ReactNode,
+  ReactElement,
 } from 'react';
 import styled, { withTheme } from 'styled-components';
 
@@ -36,5 +37,7 @@ const StyledTableHeadingCell = styled.th<TableHeadingCellProps>`
  */
 
 const TableHeadingCell = withTheme(StyledTableHeadingCell);
+
+declare type TableHeadingCell = ReactElement<TableHeadingCellProps>;
 
 export default TableHeadingCell;

--- a/src/Tables/TableHeadingSpacer.tsx
+++ b/src/Tables/TableHeadingSpacer.tsx
@@ -1,4 +1,5 @@
-import styled from 'styled-components';
+import styled, { StyledComponent } from 'styled-components';
+import { ReactElement } from 'react';
 
 /**
  * @component
@@ -6,7 +7,7 @@ import styled from 'styled-components';
  * blank space to use in complicated, multi-layer headers.
  */
 
-const TableHeadingSpacer = styled.td`
+const TableHeadingSpacer: StyledComponent<'td', {}> = styled.td`
   background-color: none;
   border: none;
   color: transparent;
@@ -14,5 +15,7 @@ const TableHeadingSpacer = styled.td`
     background-color: none;
   }
 `;
+
+declare type TableHeadingSpacer = ReactElement<{}>;
 
 export default TableHeadingSpacer;

--- a/src/Tables/TableHeadingSpacer.tsx
+++ b/src/Tables/TableHeadingSpacer.tsx
@@ -1,0 +1,18 @@
+import styled from 'styled-components';
+
+/**
+ * @component
+ * Renders a blank/transparent table data cell. Primarily intended for adding
+ * blank space to use in complicated, multi-layer headers.
+ */
+
+const TableHeadingSpacer = styled.td`
+  background-color: none;
+  border: none;
+  color: transparent;
+  &:hover {
+    background-color: none;
+  }
+`;
+
+export default TableHeadingSpacer;

--- a/src/Tables/TableRow.tsx
+++ b/src/Tables/TableRow.tsx
@@ -2,6 +2,7 @@ import {
   ReactElement, ReactNode,
 } from 'react';
 import styled, { withTheme } from 'styled-components';
+import { BaseTheme } from 'Theme';
 
 export interface TableRowProps {
   /** Cell components to be displayed in the row */
@@ -36,6 +37,12 @@ const TableRow = styled.tr<TableRowProps>`
 TableRow.defaultProps = {
   isStriped: false,
 };
+
+/**
+ * @component
+ * Renders a <tr> element, for use inside the TableHead and TableBody
+ * components.
+ */
 
 export type TableRow = ReactElement<TableRowProps>;
 

--- a/src/Tables/TableRow.tsx
+++ b/src/Tables/TableRow.tsx
@@ -21,7 +21,7 @@ export interface TableRowProps {
   theme: BaseTheme;
 }
 
-const TableRow = styled.tr<TableRowProps>`
+const StyledTableRow = styled.tr<TableRowProps>`
   background: ${({ theme, isStriped }): string => (
     isStriped
       ? theme.color.background.subtle
@@ -34,7 +34,7 @@ const TableRow = styled.tr<TableRowProps>`
   }
 `;
 
-TableRow.defaultProps = {
+StyledTableRow.defaultProps = {
   isStriped: false,
 };
 
@@ -44,6 +44,8 @@ TableRow.defaultProps = {
  * components.
  */
 
-export type TableRow = ReactElement<TableRowProps>;
+const TableRow = withTheme(StyledTableRow);
 
-export default withTheme(TableRow);
+declare type TableRow = ReactElement<TableRowProps>;
+
+export default TableRow;

--- a/src/Tables/TableRow.tsx
+++ b/src/Tables/TableRow.tsx
@@ -6,17 +6,30 @@ import styled, { withTheme } from 'styled-components';
 export interface TableRowProps {
   /** Cell components to be displayed in the row */
   children: ReactNode;
-  /** Controls whether the background of the row has a darker background color */
+  /**
+   * Controls whether the background of the row has a darker background color
+   * Inteded for use in long tables that help differentiate even/odd rows
+   * */
   isStriped?: boolean;
+  /**
+   * By default, rows will highlight on hover. Setting this to true will
+   * disable that behavior
+   */
+  noHighlight?: boolean;
+  /** The application theme */
+  theme: BaseTheme;
 }
 
 const TableRow = styled.tr<TableRowProps>`
-  background: ${({ theme, isStriped }): string => (isStriped ? theme.color.background.subtle : theme.color.background.light)};
+  background: ${({ theme, isStriped }): string => (
+    isStriped
+      ? theme.color.background.subtle
+      : theme.color.background.light)};
   &:hover {
-    background: ${({ theme }): string => (theme.color.background.medium)};
-  }
-  th {
-    background-color: ${({ theme }): string => (theme.color.background.medium)};
+    background: ${({ theme, noHighlight }): string => (
+    noHighlight
+      ? null
+      : theme.color.background.medium)};
   }
 `;
 

--- a/src/Tables/TableRow.tsx
+++ b/src/Tables/TableRow.tsx
@@ -1,12 +1,20 @@
 import {
-  ReactElement, ReactNode,
+  ReactElement, ForwardRefExoticComponent,
 } from 'react';
 import styled, { withTheme } from 'styled-components';
 import { BaseTheme } from 'Theme';
+import TableRowHeadingCell from './TableRowHeadingCell';
+import TableCell from './TableCell';
+import TableHeadingCell from './TableHeadingCell';
+import TableHeadingSpacer from './TableHeadingSpacer';
 
 export interface TableRowProps {
   /** Cell components to be displayed in the row */
-  children: ReactNode;
+  children: (
+    TableCell | TableHeadingCell| TableRowHeadingCell | TableHeadingSpacer
+  ) | (
+    TableCell | TableHeadingCell| TableRowHeadingCell | TableHeadingSpacer
+  )[];
   /**
    * Controls whether the background of the row has a darker background color
    * Inteded for use in long tables that help differentiate even/odd rows
@@ -18,7 +26,7 @@ export interface TableRowProps {
    */
   noHighlight?: boolean;
   /** The application theme */
-  theme: BaseTheme;
+  theme?: BaseTheme;
 }
 
 const StyledTableRow = styled.tr<TableRowProps>`
@@ -44,7 +52,8 @@ StyledTableRow.defaultProps = {
  * components.
  */
 
-const TableRow = withTheme(StyledTableRow);
+const TableRow:
+ForwardRefExoticComponent<TableRowProps> = withTheme(StyledTableRow);
 
 declare type TableRow = ReactElement<TableRowProps>;
 

--- a/src/Tables/TableRowHeadingCell.tsx
+++ b/src/Tables/TableRowHeadingCell.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react';
+import { ReactNode, ReactElement } from 'react';
 import styled, { withTheme } from 'styled-components';
 import { ALIGN } from './TableCell';
 
@@ -33,5 +33,7 @@ const StyledTableHeadingCell = styled.th<TableRowHeadingCellProps>`
  * component, for use as a row-level header.
  */
 const TableRowHeadingCell = withTheme(StyledTableHeadingCell);
+
+declare type TableRowHeadingCell = ReactElement<TableRowHeadingCellProps>;
 
 export default TableRowHeadingCell;

--- a/src/Tables/TableRowHeadingCell.tsx
+++ b/src/Tables/TableRowHeadingCell.tsx
@@ -1,5 +1,8 @@
-import { ReactNode, ReactElement } from 'react';
-import styled, { withTheme } from 'styled-components';
+import {
+  ReactNode, ReactElement, RefForwardingComponent, ForwardRefExoticComponent,
+} from 'react';
+import styled, { withTheme, StyledComponent } from 'styled-components';
+import { BaseTheme } from 'Theme';
 import { ALIGN } from './TableCell';
 
 export interface TableRowHeadingCellProps {
@@ -15,6 +18,8 @@ export interface TableRowHeadingCellProps {
   rowSpan?: number;
   /** Specifies the group of cells that the row heading refers to */
   scope: 'row' | 'rowgroup' | 'auto';
+  /** The application theme */
+  theme?: BaseTheme;
 }
 
 const StyledTableHeadingCell = styled.th<TableRowHeadingCellProps>`
@@ -32,7 +37,9 @@ const StyledTableHeadingCell = styled.th<TableRowHeadingCellProps>`
  * Renders a <th> element that is stylistically similar to the TableCell
  * component, for use as a row-level header.
  */
-const TableRowHeadingCell = withTheme(StyledTableHeadingCell);
+const TableRowHeadingCell: ForwardRefExoticComponent<
+TableRowHeadingCellProps
+> = withTheme(StyledTableHeadingCell);
 
 declare type TableRowHeadingCell = ReactElement<TableRowHeadingCellProps>;
 

--- a/src/Tables/TableRowHeadingCell.tsx
+++ b/src/Tables/TableRowHeadingCell.tsx
@@ -1,0 +1,37 @@
+import { ReactNode } from 'react';
+import styled, { withTheme } from 'styled-components';
+import { ALIGN } from './TableCell';
+
+export interface TableRowHeadingCellProps {
+  /** Allows you to pass in a alignment property from the ALIGN enum */
+  alignment?: ALIGN;
+  /** Specifies the background color of the table cell */
+  backgroundColor?: string;
+  /** Text or components to be displayed in the table heading cell */
+  children: ReactNode;
+  /** Handles cells that span multiple columns */
+  colSpan?: number;
+  /** Handles cells that span multiple rows */
+  rowSpan?: number;
+  /** Specifies the group of cells that the row heading refers to */
+  scope: 'row' | 'rowgroup' | 'auto';
+}
+
+const StyledTableHeadingCell = styled.th<TableRowHeadingCellProps>`
+  border-left: ${({ theme }): string => (theme.border.light)};
+  border-right: ${({ theme }): string => (theme.border.light)};
+  font-weight: ${({ theme }): string => (theme.font.data.weight)};
+  font-family: ${({ theme }): string => (theme.font.data.family)};
+  font-size: ${({ theme }): string => (theme.font.data.size)};
+  text-align: ${({ alignment }): string => alignment};
+  background-color: ${({ backgroundColor }): string => backgroundColor};
+`;
+
+/**
+ * @component
+ * Renders a <th> element that is stylistically similar to the TableCell
+ * component, for use as a row-level header.
+ */
+const TableRowHeadingCell = withTheme(StyledTableHeadingCell);
+
+export default TableRowHeadingCell;

--- a/src/Tables/__tests__/Table.test.tsx
+++ b/src/Tables/__tests__/Table.test.tsx
@@ -52,9 +52,6 @@ describe('Table Components', function () {
     ));
   });
   describe('Table Cell', function () {
-    it('contains text', function () {
-      getByText('1');
-    });
     it('defaults to left text-align when alignment prop is unspecified', function () {
       const style = window.getComputedStyle(getByText('1'));
       strictEqual(style.textAlign, 'left');

--- a/src/Tables/__tests__/Table.test.tsx
+++ b/src/Tables/__tests__/Table.test.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
-import { render } from 'test-utils';
+import {
+  render, GetByText, BoundFunction, GetByBoundAttribute, AllByRole,
+} from 'test-utils';
 import convert from 'color-convert';
 import { strictEqual } from 'assert';
 import TableCell, { ALIGN } from '../TableCell';
@@ -11,9 +13,9 @@ import Table from '../Table';
 import MarkOneTheme from '../../Theme/MarkOneTheme';
 
 describe('Table Components', function () {
-  let getByText;
-  let getAllByRole;
-  let getByTestId;
+  let getByText: BoundFunction<GetByText>;
+  let getAllByRole: BoundFunction<AllByRole>;
+  let getByTestId: BoundFunction<GetByBoundAttribute>;
   beforeEach(function () {
     ({ getByText, getAllByRole, getByTestId } = render(
       <Table>

--- a/src/Tables/__tests__/Table.test.tsx
+++ b/src/Tables/__tests__/Table.test.tsx
@@ -113,6 +113,55 @@ describe('Table Components', function () {
       const convertExpectedToRGB = `rgb(${red}, ${green}, ${blue})`;
       strictEqual(style.backgroundColor, convertExpectedToRGB);
     });
+    describe('noHighlight prop', function () {
+      beforeEach(function () {
+        ({ getByText } = render(
+          <Table>
+            <TableHead>
+              <TableRow>
+                <TableHeadingCell>Regular</TableHeadingCell>
+              </TableRow>
+              <TableRow noHighlight>
+                <TableHeadingCell>noHighlight</TableHeadingCell>
+              </TableRow>
+            </TableHead>
+          </Table>
+        ));
+      });
+      it('Should not have a :hover css class with noHighlight', function () {
+        const noHighlight = getByText('noHighlight');
+        const allSheets = Array.from(document.styleSheets);
+        const sheet = allSheets[allSheets.length - 1] as CSSStyleSheet;
+        const rules = sheet.cssRules;
+        const parentClasses = noHighlight.parentElement.classList;
+        const maybeHoverClasses = Array.from(parentClasses)
+          .map((className) => `.${className}:hover`);
+        const hoverRule = Array.from(rules)
+          .find(({ selectorText }: CSSStyleRule) => (
+            maybeHoverClasses.includes(selectorText)
+          ));
+        strictEqual(hoverRule, undefined);
+      });
+      it('Should have a :hover rule without noHighlight', function () {
+        const regular = getByText('Regular');
+        const allSheets = Array.from(document.styleSheets);
+        const sheet = allSheets[allSheets.length - 1] as CSSStyleSheet;
+        const rules = sheet.cssRules;
+        const parentClasses = regular.parentElement.classList;
+        const maybeHoverClasses = Array.from(parentClasses)
+          .map((className) => `.${className}:hover`);
+        const hoverRule = Array.from(rules)
+          .find(({ selectorText }: CSSStyleRule) => (
+            maybeHoverClasses.includes(selectorText)
+          ));
+        strictEqual(
+          hoverRule
+            .cssText
+            .includes(`background: ${MarkOneTheme.color.background.medium}`),
+          true
+        );
+      });
+    });
   });
   describe('Table Body', function () {
     it('sets CSS overflow to scroll when isScrollable prop is true', function () {

--- a/src/Tables/__tests__/Table.test.tsx
+++ b/src/Tables/__tests__/Table.test.tsx
@@ -75,8 +75,29 @@ describe('Table Components', function () {
     });
   });
   describe('Table Heading Cell', function () {
-    it('contains text', function () {
-      getByText('ID');
+    beforeEach(function () {
+      ({ getByText } = render(
+        <Table>
+          <TableHead>
+            <TableRow>
+              <TableHeadingCell backgroundColor="rgb(123, 123, 123)">With Background</TableHeadingCell>
+              <TableHeadingCell>Without Background</TableHeadingCell>
+            </TableRow>
+          </TableHead>
+        </Table>
+      ));
+    });
+    it('Renders with the passed background color', function () {
+      const style = window.getComputedStyle(getByText('With Background'));
+      strictEqual(style.backgroundColor, 'rgb(123, 123, 123)');
+    });
+    it('defaults to medium with no background color', function () {
+      const style = window.getComputedStyle(getByText('Without Background'));
+      const [red, green, blue] = convert.hex.rgb(
+        MarkOneTheme.color.background.medium as string
+      );
+      const convertExpectedToRGB = `rgb(${red}, ${green}, ${blue})`;
+      strictEqual(style.backgroundColor, convertExpectedToRGB);
     });
   });
   describe('Table Row', function () {

--- a/src/Tables/index.ts
+++ b/src/Tables/index.ts
@@ -5,3 +5,4 @@ export { default as TableHead } from './TableHead';
 export { default as TableHeadingCell } from './TableHeadingCell';
 export { default as TableHeadingSpacer } from './TableHeadingSpacer';
 export { default as TableBody } from './TableBody';
+export { default as TableRowHeadingCell } from './TableRowHeadingCell';

--- a/src/Tables/index.ts
+++ b/src/Tables/index.ts
@@ -3,4 +3,5 @@ export { default as TableCell, ALIGN } from './TableCell';
 export { default as TableRow } from './TableRow';
 export { default as TableHead } from './TableHead';
 export { default as TableHeadingCell } from './TableHeadingCell';
+export { default as TableHeadingSpacer } from './TableHeadingSpacer';
 export { default as TableBody } from './TableBody';

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const fs = require('fs');
+const rdts = require('react-docgen-typescript');
 
 const guidelinesSections = fs.readdirSync(
   path.join(__dirname, 'guidelines'),
@@ -74,8 +75,13 @@ module.exports = {
     }
   },
   pagePerSection: true,
-  propsParser: require('react-docgen-typescript').withCustomConfig(
-    './tsconfig.json'
+  propsParser: rdts.withCustomConfig(
+    './tsconfig.json',
+    {
+      componentNameResolver: (exp, source) => (
+        rdts.getDefaultExportForFile(source)
+      ),
+    }
   ).parse,
   sections,
   styleguideComponents: {

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -78,6 +78,12 @@ module.exports = {
   propsParser: rdts.withCustomConfig(
     './tsconfig.json',
     {
+      propFilter: (prop, component) => {
+        if (prop.parent) {
+          return !prop.parent.fileName.includes('node_modules')
+        }
+        return true
+      },
       componentNameResolver: (exp, source) => (
         rdts.getDefaultExportForFile(source)
       ),


### PR DESCRIPTION
This PR is making a number of tweaks to our table components to accommodate the beast that is the Course Instance table. It adds two new components (a `HeadingSpacer` and `RowHeader`), updates some of the typings to allow for `col` and `colgroup` elements and multiple `TableRow` elements inside a header, and makes some general styling tweaks to get us as close as possible to Vittorio's prototype. I believe I've managed to do this while maintaining full backwards-compatibility, so there shouldn't be any breaking changes in the other course-planner tables that already exist.