### PR TITLE
Update Table Components (Revision)

### DIFF
--- a/src/Tables/Table.tsx
+++ b/src/Tables/Table.tsx
@@ -1,6 +1,6 @@
 import styled, { withTheme } from 'styled-components';
-import { BaseTheme } from 'Theme';
 import { ReactElement, ForwardRefExoticComponent } from 'react';
+import { BaseTheme } from '../Theme';
 import TableHead from './TableHead';
 import TableBody from './TableBody';
 

--- a/src/Tables/TableBody.tsx
+++ b/src/Tables/TableBody.tsx
@@ -1,6 +1,6 @@
 import { ReactElement, ForwardRefExoticComponent } from 'react';
 import styled, { withTheme } from 'styled-components';
-import { BaseTheme } from 'Theme';
+import { BaseTheme } from '../Theme';
 import TableRow from './TableRow';
 
 export interface TableBodyProps {

--- a/src/Tables/TableCell.tsx
+++ b/src/Tables/TableCell.tsx
@@ -1,6 +1,6 @@
 import { ReactNode, ReactElement, ForwardRefExoticComponent } from 'react';
 import styled, { withTheme } from 'styled-components';
-import { BaseTheme } from 'Theme';
+import { BaseTheme } from '../Theme';
 
 /** Represents the possible values for TableCell's text-align property */
 export enum ALIGN {

--- a/src/Tables/TableHead.tsx
+++ b/src/Tables/TableHead.tsx
@@ -1,6 +1,6 @@
 import styled, { withTheme } from 'styled-components';
-import { BaseTheme } from 'Theme';
 import { ReactElement, ForwardRefExoticComponent } from 'react';
+import { BaseTheme } from '../Theme';
 import TableRow from './TableRow';
 
 export interface TableHeadProps {

--- a/src/Tables/TableHeadingCell.tsx
+++ b/src/Tables/TableHeadingCell.tsx
@@ -15,9 +15,9 @@ export interface TableHeadingCellProps {
   /** Function to call on click event */
   clickHandler?: MouseEventHandler;
   /** Handles cells that span multiple columns */
-  colSpan?: number;
+  colSpan?: string;
   /** Handles cells that span multiple rows */
-  rowSpan?: number;
+  rowSpan?: string;
   /** Specifies the group of cells that the table heading refers to */
   scope?: 'col' | 'colgroup' | 'auto';
   /** The application theme */

--- a/src/Tables/TableHeadingCell.tsx
+++ b/src/Tables/TableHeadingCell.tsx
@@ -15,9 +15,9 @@ export interface TableHeadingCellProps {
   /** Function to call on click event */
   clickHandler?: MouseEventHandler;
   /** Handles cells that span multiple columns */
-  colSpan?: string;
+  colSpan?: string | number;
   /** Handles cells that span multiple rows */
-  rowSpan?: string;
+  rowSpan?: string | number;
   /** Specifies the group of cells that the table heading refers to */
   scope?: 'col' | 'colgroup' | 'auto';
   /** The application theme */

--- a/src/Tables/TableHeadingCell.tsx
+++ b/src/Tables/TableHeadingCell.tsx
@@ -5,7 +5,7 @@ import {
   ForwardRefExoticComponent,
 } from 'react';
 import styled, { withTheme } from 'styled-components';
-import { BaseTheme } from 'Theme';
+import { BaseTheme } from '../Theme';
 
 export interface TableHeadingCellProps {
   /** Specifies the background color of the table cell */

--- a/src/Tables/TableRow.tsx
+++ b/src/Tables/TableRow.tsx
@@ -2,7 +2,7 @@ import {
   ReactElement, ForwardRefExoticComponent,
 } from 'react';
 import styled, { withTheme } from 'styled-components';
-import { BaseTheme } from 'Theme';
+import { BaseTheme } from '../Theme';
 import TableRowHeadingCell from './TableRowHeadingCell';
 import TableCell from './TableCell';
 import TableHeadingCell from './TableHeadingCell';

--- a/src/Tables/TableRowHeadingCell.tsx
+++ b/src/Tables/TableRowHeadingCell.tsx
@@ -13,9 +13,9 @@ export interface TableRowHeadingCellProps {
   /** Text or components to be displayed in the table heading cell */
   children: ReactNode;
   /** Handles cells that span multiple columns */
-  colSpan?: number;
+  colSpan?: string;
   /** Handles cells that span multiple rows */
-  rowSpan?: number;
+  rowSpan?: string;
   /** Specifies the group of cells that the row heading refers to */
   scope: 'row' | 'rowgroup' | 'auto';
   /** The application theme */

--- a/src/Tables/TableRowHeadingCell.tsx
+++ b/src/Tables/TableRowHeadingCell.tsx
@@ -13,9 +13,9 @@ export interface TableRowHeadingCellProps {
   /** Text or components to be displayed in the table heading cell */
   children: ReactNode;
   /** Handles cells that span multiple columns */
-  colSpan?: string;
+  colSpan?: string | number;
   /** Handles cells that span multiple rows */
-  rowSpan?: string;
+  rowSpan?: string | number;
   /** Specifies the group of cells that the row heading refers to */
   scope: 'row' | 'rowgroup' | 'auto';
   /** The application theme */

--- a/src/Tables/TableRowHeadingCell.tsx
+++ b/src/Tables/TableRowHeadingCell.tsx
@@ -1,8 +1,8 @@
 import {
-  ReactNode, ReactElement, RefForwardingComponent, ForwardRefExoticComponent,
+  ReactNode, ReactElement, ForwardRefExoticComponent,
 } from 'react';
-import styled, { withTheme, StyledComponent } from 'styled-components';
-import { BaseTheme } from 'Theme';
+import styled, { withTheme } from 'styled-components';
+import { BaseTheme } from '../Theme';
 import { ALIGN } from './TableCell';
 
 export interface TableRowHeadingCellProps {


### PR DESCRIPTION
I made a mistake in #59, leaving in imports from 'Theme' that should have been '../Theme'. I'm also changing the type for `rowSpan` and `colSpan` from `number` to `string`, since that's closer to how regular html would be written. 

With `number` the usage would have to be:

```tsx
<TableHeadingCell colSpan={2}>Heading</TableHeadingCell>
```

While with `string` the usage would be:

```tsx
<TableHeadingCell colSpan="2">Heading</TableHeadingCell>
```