### PR TITLE
TableCellList components

### DIFF
--- a/examples/Headings/SectionHeading.md
+++ b/examples/Headings/SectionHeading.md
@@ -2,6 +2,6 @@ Renders a styled `<h2>` element for denoting the start of a new main section wit
 
 For accessibility, The `<SectionHeading>` should be below the `<PageTitle>` in the DOM, and should not be ordered within other heading elements.
 
-```tsx
+```jsx
 <SectionHeading>Section Heading</SectionHeading>
 ```

--- a/examples/Tables/Table.md
+++ b/examples/Tables/Table.md
@@ -178,7 +178,7 @@ import {
 
 Some tables may require more complex layouts, such as cells that span multiple columns/rows, or layered headers. For example:
 
-```tsx
+```jsx
 import {
   ALIGN,
   Table,

--- a/examples/Tables/Table.md
+++ b/examples/Tables/Table.md
@@ -176,7 +176,7 @@ import {
 
 ### More Complex Layouts
 
-Some tables may require more complex layouts, such as cells that span multiple columns/rows or layered, hierarchical headers. For example:
+Some tables may require more complex layouts, such as cells that span multiple columns/rows, or layered headers. For example:
 
 ```tsx
 import {
@@ -188,6 +188,8 @@ import {
   TableRowHeadingCell,
   TableHeadingCell,
   TableHeadingSpacer,
+  TableCellList,
+  TableCellListItem,
   TableHead,
 } from 'mark-one';
 
@@ -215,9 +217,9 @@ import {
     </TableRow>
     <TableRow>
       <TableHeadingCell scope="col" rowSpan="2">Course</TableHeadingCell>
-      <TableHeadingCell scope="col" rowSpan="2">Offered</TableHeadingCell>
+      <TableHeadingCell scope="col" rowSpan="2">Instructors</TableHeadingCell>
       <TableHeadingCell colSpan="3">Enrollment</TableHeadingCell>
-      <TableHeadingCell scope="col" rowSpan="2">Offered</TableHeadingCell>
+      <TableHeadingCell scope="col" rowSpan="2">Instructors</TableHeadingCell>
       <TableHeadingCell colSpan="3">Enrollment</TableHeadingCell>
     </TableRow>
     <TableRow>
@@ -232,33 +234,60 @@ import {
   <TableBody>
     <TableRow>
       <TableRowHeadingCell scope="row">CS 50</TableRowHeadingCell>
-      <TableCell>YES</TableCell>
+      <TableCell>
+        <TableCellList>
+          <TableCellListItem>
+            Glenn, Kristin
+          </TableCellListItem>
+          <TableCellListItem>
+            Thompson, Jack
+          </TableCellListItem>
+        </TableCellList>
+      </TableCell>
       <TableCell>600</TableCell>
       <TableCell>480</TableCell>
       <TableCell>300</TableCell>
-      <TableCell>NO</TableCell>
+      <TableCell></TableCell>
       <TableCell />
       <TableCell />
       <TableCell />
     </TableRow>
     <TableRow isStriped>
       <TableRowHeadingCell scope="row">CS 51</TableRowHeadingCell>
-      <TableCell>NO</TableCell>
+      <TableCell></TableCell>
       <TableCell />
       <TableCell />
       <TableCell />
-      <TableCell>YES</TableCell>
+      <TableCell>
+        <TableCellList>
+          <TableCellListItem>
+            Michaels, Lianne
+          </TableCellListItem>
+        </TableCellList>
+      </TableCell>
       <TableCell>185</TableCell>
       <TableCell>140</TableCell>
       <TableCell>120</TableCell>
     </TableRow>
     <TableRow>
       <TableRowHeadingCell scope="row">ES 100</TableRowHeadingCell>
-      <TableCell>YES</TableCell>
+      <TableCell>
+        <TableCellList>
+          <TableCellListItem>
+            Hines, Gabriela
+          </TableCellListItem>
+        </TableCellList>
+      </TableCell>
       <TableCell>250</TableCell>
       <TableCell>175</TableCell>
       <TableCell>80</TableCell>
-      <TableCell>YES</TableCell>
+      <TableCell>
+        <TableCellList>
+          <TableCellListItem>
+            Hines, Gabriela
+          </TableCellListItem>
+        </TableCellList>
+      </TableCell>
       <TableCell>300</TableCell>
       <TableCell>150</TableCell>
       <TableCell>100</TableCell>

--- a/src/Tables/TableCellList.tsx
+++ b/src/Tables/TableCellList.tsx
@@ -1,0 +1,25 @@
+import styled from 'styled-components';
+import { BaseTheme } from 'mark-one';
+import TableCellListItem from './TableCellListItem';
+
+export interface TableCellListProps {
+  /**
+   * Should only contain TableCellListItems
+   */
+  children: TableCellListItem | TableCellListItem[];
+  /**
+   * The application theme
+   */
+  theme: BaseTheme;
+}
+
+const TableCellList = styled.ol<TableCellListProps>`
+  list-style: none;
+  padding: ${({ theme }): string => (theme.ws.xsmall)};
+`;
+
+/**
+ * Used to render lists inside of table cells
+ */
+
+export default TableCellList;

--- a/src/Tables/TableCellListItem.tsx
+++ b/src/Tables/TableCellListItem.tsx
@@ -1,0 +1,26 @@
+import { ReactElement, ReactNode } from 'react';
+import styled from 'styled-components';
+import { BaseTheme } from 'mark-one';
+
+export interface TableCellListItemProps {
+  /**
+   * The application theme
+   */
+  theme: BaseTheme;
+  /**
+   * The contents of the list item
+   */
+  children: ReactNode;
+}
+
+const TableCellListItem = styled.li<TableCellListItemProps>`
+  border-top: ${({ theme }): string => (theme.border.hairline)};
+  padding: ${({ theme }): string => (theme.ws.small)} 0px;
+  &:first-child {
+    border-top: none;
+  }
+`;
+
+declare type TableCellListItem = ReactElement<TableCellListItemProps>;
+
+export default TableCellListItem;

--- a/src/Tables/index.ts
+++ b/src/Tables/index.ts
@@ -1,5 +1,7 @@
 export { default as Table } from './Table';
 export { default as TableCell, ALIGN } from './TableCell';
+export { default as TableCellList } from './TableCellList';
+export { default as TableCellListItem } from './TableCellListItem';
 export { default as TableRow } from './TableRow';
 export { default as TableHead } from './TableHead';
 export { default as TableHeadingCell } from './TableHeadingCell';


### PR DESCRIPTION
The current course-planner prototypes frequently use lists inside of a TableCell. I think it makes sense to have this as a special, Table specific design (as opposed to a more generalized List design), since this will probably be a pattern we employ in other circumstances.

This is needed for the work in seas-computing/course-planner#196