### PR TITLE
Add verticalAlignment prop to TableCells

### DIFF
--- a/src/Tables/TableCell.tsx
+++ b/src/Tables/TableCell.tsx
@@ -9,12 +9,24 @@ export enum ALIGN {
   CENTER = 'center',
 }
 
+/** Represents the possible values for TableCell's text-align property */
+export enum VALIGN {
+  TOP = 'top',
+  BOTTOM = 'bottom',
+  CENTER = 'center',
+}
+
 export interface TableCellProps {
   /**
    * Allows you to pass in a alignment property from the ALIGN enum.
    * Defaults to ALIGN.LEFT
    */
   alignment?: ALIGN;
+  /**
+   * Allows for customizing the vertal alignment of the cell content
+   * Defaults to VALIGN.CENTER
+   */
+  verticalAlignment?: VALIGN;
   /** Specifies the background color of the table cell */
   backgroundColor?: string;
   /** Text or components to be displayed in the cell */
@@ -30,11 +42,13 @@ const StyledCell = styled.td<TableCellProps>`
   font-size: ${({ theme }): string => (theme.font.data.size)};
   padding: ${({ theme }): string => (theme.ws.xsmall)};
   text-align: ${({ alignment }): string => alignment};
+  vertical-align: ${({ verticalAlignment }): string => verticalAlignment};
   background-color: ${({ backgroundColor }): string => backgroundColor};
 `;
 
 StyledCell.defaultProps = {
   alignment: ALIGN.LEFT,
+  verticalAlignment: VALIGN.CENTER,
 };
 
 /**

--- a/src/Tables/TableRowHeadingCell.tsx
+++ b/src/Tables/TableRowHeadingCell.tsx
@@ -3,11 +3,13 @@ import {
 } from 'react';
 import styled, { withTheme } from 'styled-components';
 import { BaseTheme } from '../Theme';
-import { ALIGN } from './TableCell';
+import { ALIGN, VALIGN } from './TableCell';
 
 export interface TableRowHeadingCellProps {
   /** Allows you to pass in a alignment property from the ALIGN enum */
   alignment?: ALIGN;
+  /** Allows for customizing the vertal alignment of the cell content */
+  verticalAlignment?: VALIGN;
   /** Specifies the background color of the table cell */
   backgroundColor?: string;
   /** Text or components to be displayed in the table heading cell */
@@ -22,16 +24,21 @@ export interface TableRowHeadingCellProps {
   theme?: BaseTheme;
 }
 
-const StyledTableHeadingCell = styled.th<TableRowHeadingCellProps>`
+const StyledTableRowHeadingCell = styled.th<TableRowHeadingCellProps>`
   border-left: ${({ theme }): string => (theme.border.light)};
   border-right: ${({ theme }): string => (theme.border.light)};
   font-weight: ${({ theme }): string => (theme.font.data.weight)};
   font-family: ${({ theme }): string => (theme.font.data.family)};
   font-size: ${({ theme }): string => (theme.font.data.size)};
   text-align: ${({ alignment }): string => alignment};
+  vertical-align: ${({ verticalAlignment }): string => verticalAlignment};
   background-color: ${({ backgroundColor }): string => backgroundColor};
 `;
 
+StyledTableRowHeadingCell.defaultProps = {
+  alignment: ALIGN.LEFT,
+  verticalAlignment: VALIGN.CENTER,
+};
 /**
  * @component
  * Renders a <th> element that is stylistically similar to the TableCell
@@ -39,7 +46,7 @@ const StyledTableHeadingCell = styled.th<TableRowHeadingCellProps>`
  */
 const TableRowHeadingCell: ForwardRefExoticComponent<
 TableRowHeadingCellProps
-> = withTheme(StyledTableHeadingCell);
+> = withTheme(StyledTableRowHeadingCell);
 
 declare type TableRowHeadingCell = ReactElement<TableRowHeadingCellProps>;
 

--- a/src/Tables/index.ts
+++ b/src/Tables/index.ts
@@ -1,5 +1,5 @@
 export { default as Table } from './Table';
-export { default as TableCell, ALIGN } from './TableCell';
+export { default as TableCell, ALIGN, VALIGN } from './TableCell';
 export { default as TableCellList } from './TableCellList';
 export { default as TableCellListItem } from './TableCellListItem';
 export { default as TableRow } from './TableRow';


### PR DESCRIPTION
This will allow us to vertically align the text inside of the TableCell and TableRowHeadingCell components, as discussed during the spring review session from 05/22. 

This was meant to include f49de4469ffd1566a677600fcdecdcc3413e5584, but I accidentally pushed that up to `develop` instead of the feature branch.