### PR TITLE
Add 'id' property to Dropdown component

### DIFF
--- a/examples/Dropdown/Dropdown.md
+++ b/examples/Dropdown/Dropdown.md
@@ -1,13 +1,12 @@
 ```jsx
       import { useState } from 'react';
-      import { Label } from 'mark-one';
       function DropdownExample() {
         const [value, setValue] = useState('fall');
         return (
-          <Label
+          <label
             htmlFor="semesters"
-            label="Semester:"
           >
+          Semester:
           <Dropdown
           options={[
             {
@@ -28,7 +27,7 @@
             alert('You changed the selection to ' + event.target.value);
           }}
         />
-        </Label>
+        </label>
         );
       }
       <DropdownExample />

--- a/examples/Dropdown/Dropdown.md
+++ b/examples/Dropdown/Dropdown.md
@@ -1,8 +1,14 @@
 ```jsx
       import { useState } from 'react';
+      import { Label } from 'mark-one';
       function DropdownExample() {
         const [value, setValue] = useState('fall');
-        return (<Dropdown
+        return (
+          <Label
+            htmlFor="semesters"
+            label="Semester:"
+          >
+          <Dropdown
           options={[
             {
               value: 'all', label: 'All',
@@ -21,7 +27,9 @@
             setValue(event.target.value);
             alert('You changed the selection to ' + event.target.value);
           }}
-        />);
+        />
+        </Label>
+        );
       }
       <DropdownExample />
 ```

--- a/examples/Dropdown/Dropdown.md
+++ b/examples/Dropdown/Dropdown.md
@@ -15,6 +15,7 @@
             },
           ]}
           value={value}
+          id="semesters"
           name="semesters"
           onChange={function(event){
             setValue(event.target.value);

--- a/src/Dropdown/Dropdown.tsx
+++ b/src/Dropdown/Dropdown.tsx
@@ -8,6 +8,8 @@ import styled, { ThemeContext } from 'styled-components';
 import { BaseTheme } from '../Theme';
 
 export interface DropdownProps {
+  /** The id of the label tied to this dropdown field */
+  id: string;
   /** Function to call on change event */
   onChange: ChangeEventHandler;
   /** The name of the dropdown */
@@ -27,6 +29,7 @@ const StyledDropdown = styled.select`
 
 const Dropdown: FunctionComponent<DropdownProps> = (props): ReactElement => {
   const {
+    id,
     onChange,
     name,
     options,
@@ -36,6 +39,7 @@ const Dropdown: FunctionComponent<DropdownProps> = (props): ReactElement => {
   const theme: BaseTheme = useContext(ThemeContext);
   return (
     <StyledDropdown
+      id={id}
       onChange={onChange}
       theme={theme}
       name={name}

--- a/src/Dropdown/__tests__/Dropdown.test.tsx
+++ b/src/Dropdown/__tests__/Dropdown.test.tsx
@@ -23,6 +23,7 @@ describe('Dropdown', function () {
     changeSpy = spy();
     ({ getByText, getAllByRole } = render(
       <Dropdown
+        id="semesters"
         options={options}
         value="fall"
         name="semesters"

--- a/src/Forms/index.ts
+++ b/src/Forms/index.ts
@@ -1,3 +1,2 @@
 export { default as ValidationErrorMessage } from './ValidationErrorMessage';
 export { default as TextInput } from './TextInput';
-export { default as Label } from './Label';

--- a/src/Forms/index.ts
+++ b/src/Forms/index.ts
@@ -1,2 +1,3 @@
 export { default as ValidationErrorMessage } from './ValidationErrorMessage';
 export { default as TextInput } from './TextInput';
+export { default as Label } from './Label';


### PR DESCRIPTION
The id property is needed to associate the label of the dropdown with the dropdown itself. I've added the id property to component in component definition, test component, and markdown example.

## Types of changes
<!--
  What types of changes does your code introduce? Put an `x` in all the boxes
  that apply:
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
<!--
  Go over all the following points, and put an `x` in all the boxes that apply.
-->
- [x] I have run `eslint` on the code
- [x] I have added JSDoc for all of my code (where applicable)
- [ ] I have added tests to cover my changes.

## Priority:
- [x] Normal <!-- New piece of functionality -->
- [ ] High <!-- Critical bug requiring urgent review -->

## Related Issues:
<!--
  Add the issue number in below that this PR is intended to address.

  Also mention any issues that this PR is related to, and if possible,
  provide more information regarding the relationship to the issues in
  question (i.e does the PR fix the issue, is it designed to fix another bug
  that is similar to the issue etc.)
-->
Addresses [#214](https://github.com/seas-computing/course-planner/issues/214)

<!--
  Attribution:
  PR Template adapted from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->