### PR TITLE
TextInput & Dropdown: Add forwardRef prop to add ability to shift focus to these components

### DIFF
--- a/examples/Forms/Dropdown.md
+++ b/examples/Forms/Dropdown.md
@@ -363,3 +363,123 @@ Required selection example: The optional `isRequired` property is set, which cau
       }
       <DropdownExample />
 ```
+
+Ref example: The optional `forwardRef` property is set. When the test button is
+clicked, the focus shifts to the dropdown.
+```jsx
+      import { useState, useRef, } from 'react';
+      import { VARIANT } from 'Theme';
+      import { Button } from 'mark-one';
+      const RefExample = () => {
+        const ref = useRef(null);
+        const [value, setValue] = useState('');
+        const onButtonClick = () => {
+          ref.current.focus();
+        }
+        return (
+          <>
+            <Button
+              onClick={onButtonClick}
+              variant={VARIANT.INFO}
+            >
+              Focus the input
+            </Button>
+            <Dropdown
+              options={[
+                {
+                  value: 'all',
+                  label: 'All',
+                },
+                {
+                  value: 'fall',
+                  label: 'Fall',
+                },
+                {
+                  value: 'spring',
+                  label: 'Spring',
+                },
+              ]}
+              value={value}
+              id="semesters"
+              name="semesters"
+              onChange={function(event){
+                setValue(event.target.value);
+                alert('You changed the selection to ' + event.target.value);
+              }}
+              label="Semester"
+              forwardRef={ref}
+            />
+          </>
+        );
+      };
+      <RefExample />
+```
+
+Ref example: The optional `forwardRef` property is set. When the test button is
+clicked, the focus shifts to the dropdown in the modal.
+```jsx
+      import { useState, useRef, } from 'react';
+      import { VARIANT } from 'Theme';
+      import { Button, Modal, ModalBody, } from 'mark-one';
+      const RefExample = () => {
+        const ref = useRef(null);
+        const [value, setValue] = useState('');
+        const [modalVisible, setModalVisible] = useState(false);
+        const onButtonClick = () => {
+          setModalVisible(true);
+          /* Since modal may not have been rendered in DOM, wait for it to be
+          rendered by letting next task of event queue run first */
+          setTimeout(() => ref.current.focus(), 0);
+        }
+        return (
+          <>
+            <Button
+              onClick={onButtonClick}
+              variant={VARIANT.INFO}
+            >
+              Focus the input
+            </Button>
+            <Modal
+              ariaLabelledBy="testButton"
+              closeHandler={() => {setModalVisible(false)}}
+              isVisible={modalVisible}
+            >
+              <ModalBody>
+                <Dropdown
+                  options={[
+                    {
+                      value: 'all',
+                      label: 'All',
+                    },
+                    {
+                      value: 'fall',
+                      label: 'Fall',
+                    },
+                    {
+                      value: 'spring',
+                      label: 'Spring',
+                    },
+                  ]}
+                  value={value}
+                  id="semesters"
+                  name="semesters"
+                  onChange={function(event){
+                    setValue(event.target.value);
+                    alert('You changed the selection to ' + event.target.value);
+                  }}
+                  label="Semester"
+                  forwardRef={ref}
+                />
+                <Button
+                  onClick={() => setModalVisible(false)}
+                  variant={VARIANT.BASE}
+                >
+                  Close Modal
+                </Button>
+              </ModalBody>
+            </Modal>
+          </>
+        );
+      };
+      <RefExample />
+```

--- a/examples/Forms/TextInput.md
+++ b/examples/Forms/TextInput.md
@@ -188,3 +188,31 @@ Required selection example: The optional `isRequired` property is set, which cau
   }
   <TextInputExample />
 ```
+
+Ref example
+```jsx
+  import { useState, useRef, } from 'react';
+  import { Button } from 'mark-one';
+  const RefExample = () => {
+    const ref = useRef(null);
+    const [value, setValue] = useState('');
+    const onButtonClick = () => {
+      ref.current.focus();
+    }
+    return (
+      <>
+        <Button onClick={onButtonClick}>Focus the input</Button>
+        <TextInput
+            value={value}
+            name="example"
+            label="Description:"
+            onChange={(event) => {
+              setValue(event.target.value);
+            }}
+            forwardRef={ref}
+          />
+      </>
+    );
+  };
+  <RefExample />
+```

--- a/examples/Forms/TextInput.md
+++ b/examples/Forms/TextInput.md
@@ -193,6 +193,7 @@ Ref example: When the button is clicked, the focus shifts from the button itself
 the text input field.
 ```jsx
   import { useState, useRef, } from 'react';
+  import { VARIANT } from 'Theme';
   import { Button } from 'mark-one';
   const RefExample = () => {
     const ref = useRef(null);
@@ -202,8 +203,14 @@ the text input field.
     }
     return (
       <>
-        <Button onClick={onButtonClick}>Focus the input</Button>
+        <Button
+          onClick={onButtonClick}
+          variant={VARIANT.INFO}
+        >
+          Focus the input
+        </Button>
         <TextInput
+            id="example"
             value={value}
             name="example"
             label="Description:"
@@ -221,6 +228,7 @@ Ref example: When the button is clicked, the focus shifts from the button itself
 the text input field inside a modal.
 ```jsx
   import { useState, useRef, } from 'react';
+  import { VARIANT } from 'Theme';
   import { Button, Modal, ModalBody, } from 'mark-one';
 
   const RefExample = () => {
@@ -235,7 +243,12 @@ the text input field inside a modal.
     }
     return (
       <>
-        <Button onClick={onButtonClick}>Focus the input</Button>
+        <Button
+          onClick={onButtonClick}
+          variant={VARIANT.INFO}
+        >
+          Focus the input
+        </Button>
         <Modal
           ariaLabelledBy="testButton"
           closeHandler={() => {setModalVisible(false)}}

--- a/examples/Forms/TextInput.md
+++ b/examples/Forms/TextInput.md
@@ -189,8 +189,8 @@ Required selection example: The optional `isRequired` property is set, which cau
   <TextInputExample />
 ```
 
-Ref example: When the button is clicked, the focus shifts from the button itself to
-the text input field.
+Ref example: The optional `forwardRef` property is set. When the test button is
+clicked, the focus shifts from the button itself to the text input field.
 ```jsx
   import { useState, useRef, } from 'react';
   import { VARIANT } from 'Theme';
@@ -224,8 +224,9 @@ the text input field.
   };
   <RefExample />
 ```
-Ref example: When the button is clicked, the focus shifts from the button itself to
-the text input field inside a modal.
+Ref example: The optional `forwardRef` property is set. When the button is
+clicked, the focus shifts from the button itself to the text input field inside
+a modal.
 ```jsx
   import { useState, useRef, } from 'react';
   import { VARIANT } from 'Theme';
@@ -237,8 +238,8 @@ the text input field inside a modal.
     const [modalVisible, setModalVisible] = useState(false);
     const onButtonClick = () => {
       setModalVisible(true);
-      // Since modal may not have been rendered in DOM, wait for it to be rendered
-      // by letting next task of event queue run first
+      /* Since modal may not have been rendered in DOM, wait for it to be
+      rendered by letting next task of event queue run first */
       setTimeout(() => ref.current.focus(), 0);
     }
     return (
@@ -264,7 +265,10 @@ the text input field inside a modal.
               }}
               forwardRef={ref}
             />
-            <Button onClick={() => setModalVisible(false)}>
+            <Button
+              onClick={() => setModalVisible(false)}
+              variant={VARIANT.BASE}
+            >
               Close Modal
             </Button>
           </ModalBody>

--- a/examples/Forms/TextInput.md
+++ b/examples/Forms/TextInput.md
@@ -189,7 +189,8 @@ Required selection example: The optional `isRequired` property is set, which cau
   <TextInputExample />
 ```
 
-Ref example
+Ref example: When the button is clicked, the focus shifts from the button itself to
+the text input field.
 ```jsx
   import { useState, useRef, } from 'react';
   import { Button } from 'mark-one';
@@ -210,7 +211,51 @@ Ref example
               setValue(event.target.value);
             }}
             forwardRef={ref}
-          />
+        />
+      </>
+    );
+  };
+  <RefExample />
+```
+Ref example: When the button is clicked, the focus shifts from the button itself to
+the text input field inside a modal.
+```jsx
+  import { useState, useRef, } from 'react';
+  import { Button, Modal, ModalBody, } from 'mark-one';
+
+  const RefExample = () => {
+    const ref = useRef(null);
+    const [value, setValue] = useState('');
+    const [modalVisible, setModalVisible] = useState(false);
+    const onButtonClick = () => {
+      setModalVisible(true);
+      // Since modal may not have been rendered in DOM, wait for it to be rendered
+      // by letting next task of event queue run first
+      setTimeout(() => ref.current.focus(), 0);
+    }
+    return (
+      <>
+        <Button onClick={onButtonClick}>Focus the input</Button>
+        <Modal
+          ariaLabelledBy="testButton"
+          closeHandler={() => {setModalVisible(false)}}
+          isVisible={modalVisible}
+        >
+          <ModalBody>
+            <TextInput
+              value={value}
+              name="example"
+              label="Description:"
+              onChange={(event) => {
+                setValue(event.target.value);
+              }}
+              forwardRef={ref}
+            />
+            <Button onClick={() => setModalVisible(false)}>
+              Close Modal
+            </Button>
+          </ModalBody>
+        </Modal>
       </>
     );
   };

--- a/src/Forms/Dropdown.tsx
+++ b/src/Forms/Dropdown.tsx
@@ -3,6 +3,7 @@ import React, {
   FunctionComponent,
   useContext,
   ChangeEventHandler,
+  Ref,
 } from 'react';
 import styled, { ThemeContext } from 'styled-components';
 import { BaseTheme } from '../Theme';
@@ -41,6 +42,8 @@ export interface DropdownProps {
   labelPosition?: POSITION;
   /** If true, label will be visible */
   isLabelVisible?: boolean;
+  /** Specifies the ref of the dropdown */
+  forwardRef?: Ref<HTMLSelectElement>;
 }
 
 const StyledDropdown = styled.select`
@@ -62,6 +65,7 @@ const Dropdown: FunctionComponent<DropdownProps> = (props): ReactElement => {
     label,
     labelPosition,
     isLabelVisible,
+    forwardRef,
   } = props;
   const theme: BaseTheme = useContext(ThemeContext);
   return (
@@ -80,6 +84,7 @@ const Dropdown: FunctionComponent<DropdownProps> = (props): ReactElement => {
         value={value}
         defaultValue={defaultValue}
         aria-required={isRequired}
+        ref={forwardRef}
       >
         {options.map((option) => (
           <option

--- a/src/Forms/TextInput.tsx
+++ b/src/Forms/TextInput.tsx
@@ -3,6 +3,7 @@ import React, {
   useContext,
   ChangeEventHandler,
   FunctionComponent,
+  Ref,
 } from 'react';
 import styled, { ThemeContext } from 'styled-components';
 import { BaseTheme } from '../Theme/index';
@@ -36,6 +37,8 @@ export interface TextInputProps {
   isLabelVisible?: boolean;
   /** If true, the input for the text field is required to submit the form */
   isRequired?: boolean;
+  /** Specifies the ref of the text input */
+  forwardRef?: Ref<HTMLInputElement>;
 }
 
 const StyledTextInput = styled.input<TextInputProps>`
@@ -63,6 +66,7 @@ const TextInput: FunctionComponent<TextInputProps> = (props): ReactElement => {
     labelPosition,
     isLabelVisible,
     isRequired,
+    forwardRef,
   } = props;
   const theme: BaseTheme = useContext(ThemeContext);
   return (
@@ -84,6 +88,7 @@ const TextInput: FunctionComponent<TextInputProps> = (props): ReactElement => {
         disabled={disabled}
         label={label}
         aria-required={isRequired}
+        ref={forwardRef}
       />
       {errorMessage
       && (

--- a/src/Forms/__tests__/Dropdown.test.tsx
+++ b/src/Forms/__tests__/Dropdown.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import {
   render,
   fireEvent,
@@ -10,6 +10,8 @@ import {
 import { spy } from 'sinon';
 import { strictEqual, deepStrictEqual } from 'assert';
 import { POSITION } from 'Forms/Label';
+import { Button } from 'Buttons';
+import { VARIANT } from 'Theme';
 import Dropdown from '../Dropdown';
 
 describe('Dropdown', function () {
@@ -496,6 +498,62 @@ describe('Dropdown', function () {
     it('positions the label to the left of the dropdown', function () {
       const style = window.getComputedStyle(getByText('semesters').parentNode as HTMLElement);
       strictEqual(style['grid-template-areas'], '"l i i" ". e e"');
+    });
+  });
+  context('when forwardRef prop is present', function () {
+    const dropdownId = 'semester';
+    beforeEach(function () {
+      changeSpy = spy();
+      const RefExample = () => {
+        const ref = useRef(null);
+        const onButtonClick = () => {
+          ref.current.focus();
+        };
+        return (
+          <>
+            <Button
+              id="testButton"
+              onClick={onButtonClick}
+              variant={VARIANT.INFO}
+            >
+              Focus the input
+            </Button>
+            <Dropdown
+              id={dropdownId}
+              options={options}
+              value="fall"
+              label="semesters"
+              name="semesters"
+              onChange={changeSpy}
+              forwardRef={ref}
+            />
+          </>
+        );
+      };
+      ({ getByText } = render(
+        <RefExample />
+      ));
+    });
+    it('renders', function () {
+      getByText('Spring');
+    });
+    it('calls the change handler when changed', function () {
+      fireEvent.change(document.getElementsByName('semesters')[0]);
+      strictEqual(changeSpy.callCount, 1);
+    });
+    it('contains the expected elements', function () {
+      const dropdownOptionsCount = getAllByRole('option').length;
+      strictEqual(dropdownOptionsCount, options.length);
+    });
+    it('renders the correct default value', function () {
+      const dropdown = document.getElementsByName('semesters')[0] as HTMLSelectElement;
+      const defaultValue = dropdown.value;
+      strictEqual(defaultValue, 'fall');
+    });
+    it('can be used to shift the focus to the dropdown on button click', function () {
+      const testButton = document.getElementById('testButton') as HTMLButtonElement;
+      testButton.click();
+      strictEqual(document.activeElement.id, dropdownId);
     });
   });
 });

--- a/src/Forms/__tests__/TextInput.test.tsx
+++ b/src/Forms/__tests__/TextInput.test.tsx
@@ -316,7 +316,7 @@ describe('Text input', function () {
       strictEqual(style['grid-template-areas'], '"l i i" ". e e"');
     });
   });
-  context('when ref prop is present', function () {
+  context('when forwardRef prop is present', function () {
     const textInputId = 'semester';
     beforeEach(function () {
       changeSpy = spy();
@@ -357,7 +357,7 @@ describe('Text input', function () {
       const { value } = document.getElementById('semester') as HTMLInputElement;
       strictEqual(value, 'Fall');
     });
-    it('shifts the focus to the text input field on button click', function () {
+    it('can be used to shift the focus to the text input field on button click', function () {
       const testButton = document.getElementById('testButton') as HTMLButtonElement;
       testButton.click();
       strictEqual(document.activeElement.id, textInputId);

--- a/src/Forms/__tests__/TextInput.test.tsx
+++ b/src/Forms/__tests__/TextInput.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import {
   render,
   fireEvent,
@@ -10,6 +10,8 @@ import {
 import { spy } from 'sinon';
 import { strictEqual } from 'assert';
 import userEvent from '@testing-library/user-event';
+import { Button } from 'Buttons';
+import { VARIANT } from 'Theme';
 import TextInput from '../TextInput';
 
 enum POSITION {
@@ -312,6 +314,53 @@ describe('Text input', function () {
     it('positions the label to the left of the text input field', function () {
       const style = window.getComputedStyle(getByText('visibleLabel').parentNode as HTMLElement);
       strictEqual(style['grid-template-areas'], '"l i i" ". e e"');
+    });
+  });
+  context('when ref prop is present', function () {
+    const textInputId = 'semester';
+    beforeEach(function () {
+      changeSpy = spy();
+      const RefExample = () => {
+        const ref = useRef(null);
+        const onButtonClick = () => {
+          ref.current.focus();
+        };
+        return (
+          <>
+            <Button
+              id="testButton"
+              onClick={onButtonClick}
+              variant={VARIANT.INFO}
+            >
+              Focus the input
+            </Button>
+            <TextInput
+              id={textInputId}
+              name="semester"
+              value="Fall"
+              label="visibleLabel"
+              onChange={changeSpy}
+              forwardRef={ref}
+            />
+          </>
+        );
+      };
+      ({ getByText } = render(
+        <RefExample />
+      ));
+    });
+    it('renders', function () {
+      const inputElement = document.getElementById('semester') as HTMLInputElement;
+      strictEqual(!!inputElement, true);
+    });
+    it('renders the correct default value', function () {
+      const { value } = document.getElementById('semester') as HTMLInputElement;
+      strictEqual(value, 'Fall');
+    });
+    it('shifts the focus to the text input field on button click', function () {
+      const testButton = document.getElementById('testButton') as HTMLButtonElement;
+      testButton.click();
+      strictEqual(document.activeElement.id, textInputId);
     });
   });
 });


### PR DESCRIPTION
This pull request adds an optional `forwardRef` prop to the `TextInput` and `Dropdown` components. This will allow us to shift the focus to these components, and this change was motivated by making our `Course Planning` modals more accessible. Examples of doing this are included in the `TextInput` and `Dropdown` markdown files.

## Types of changes
<!--
  What types of changes does your code introduce? Put an `x` in all the boxes
  that apply:
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
<!--
  Go over all the following points, and put an `x` in all the boxes that apply.
-->
- [x] I have run `eslint` on the code
- [x] I have added JSDoc for all of my code (where applicable)
- [x] I have added tests to cover my changes.

## Priority:
- [x] Normal <!-- New piece of functionality -->
- [ ] High <!-- Critical bug requiring urgent review -->

## Related Issues:
<!--
  Add the issue number in below that this PR is intended to address.

  Also mention any issues that this PR is related to, and if possible,
  provide more information regarding the relationship to the issues in
  question (i.e does the PR fix the issue, is it designed to fix another bug
  that is similar to the issue etc.)
-->
Addresses [#235](https://github.com/seas-computing/course-planner/issues/235)

<!--
  Attribution:
  PR Template adapted from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->