### PR TITLE
Modal and ModalHeader components - Trap Focus in Modal when Modal is Visible

### DIFF
--- a/examples/Modals/ModalHeader.md
+++ b/examples/Modals/ModalHeader.md
@@ -77,3 +77,85 @@ const [modalVisible, setModalVisible] = useState(false);
   </Modal>
 </>
 ```
+
+### With the `forwardRef`
+Ref example: The optional `forwardRef` property is set. When the test button is
+clicked, the focus shifts to the modal header.
+```jsx
+import { useState, useRef, } from 'react';
+import { VARIANT } from 'Theme';
+import {
+  Button,
+  Dropdown,
+  Modal,
+  ModalBody,
+} from 'mark-one';
+
+const RefExample = () => {
+  const ref = useRef(null);
+  const [value, setValue] = useState('');
+  const [modalVisible, setModalVisible] = useState(false);
+  const onButtonClick = () => {
+    setModalVisible(true);
+    /* Since modal may not have been rendered in DOM, wait for it to be
+    rendered by letting next task of event queue run first */
+    setTimeout(() => ref.current.focus(), 0);
+  }
+  return (
+    <>
+      <Button
+        onClick={onButtonClick}
+        variant={VARIANT.INFO}
+      >
+        Focus the input
+      </Button>
+      <Modal
+        ariaLabelledBy="testButton"
+        closeHandler={() => {setModalVisible(false)}}
+        isVisible={modalVisible}
+      >
+        <ModalHeader
+          closeButtonHandler={() => {setModalVisible(false)}}
+          tabIndex={0}
+          forwardRef={ref}
+        >
+          Modal Header
+        </ModalHeader>
+        <ModalBody>
+          <Dropdown
+            options={[
+              {
+                value: 'all',
+                label: 'All',
+              },
+              {
+                value: 'fall',
+                label: 'Fall',
+              },
+              {
+                value: 'spring',
+                label: 'Spring',
+              },
+            ]}
+            value={value}
+            id="semesters"
+            name="semesters"
+            onChange={function(event){
+              setValue(event.target.value);
+              alert('You changed the selection to ' + event.target.value);
+            }}
+            label="Semester"
+          />
+          <Button
+            onClick={() => setModalVisible(false)}
+            variant={VARIANT.BASE}
+          >
+            Close Modal
+          </Button>
+        </ModalBody>
+      </Modal>
+    </>
+  );
+};
+<RefExample />
+```

--- a/examples/Modals/ModalHeader.md
+++ b/examples/Modals/ModalHeader.md
@@ -99,7 +99,7 @@ const RefExample = () => {
     setModalVisible(true);
     /* Since modal may not have been rendered in DOM, wait for it to be
     rendered by letting next task of event queue run first */
-    setTimeout(() => ref.current.focus(), 0);
+    setTimeout(() => ref.current.focus());
   }
   return (
     <>

--- a/examples/Modals/ModalHeader.md
+++ b/examples/Modals/ModalHeader.md
@@ -107,7 +107,7 @@ const RefExample = () => {
         onClick={onButtonClick}
         variant={VARIANT.INFO}
       >
-        Focus the input
+        Focus the Header
       </Button>
       <Modal
         ariaLabelledBy="testButton"
@@ -140,7 +140,7 @@ const RefExample = () => {
             value={value}
             id="semesters"
             name="semesters"
-            onChange={function(event){
+            onChange={(event) => {
               setValue(event.target.value);
               alert('You changed the selection to ' + event.target.value);
             }}

--- a/src/Modals/Modal.tsx
+++ b/src/Modals/Modal.tsx
@@ -133,7 +133,8 @@ const Modal: FunctionComponent<ModalProps> = ({
   const theme = useContext(ThemeContext);
 
   // If the ref is not provided, create one since it is used below
-  const finalForwardRef = forwardRef != null ? forwardRef : useRef(null);
+  const backupRef: React.RefObject<HTMLDivElement> = useRef(null);
+  const finalForwardRef = forwardRef != null ? forwardRef : backupRef;
 
   // Encompasses all of the elements that can be focused on by the user
   // If you set the index of an element to -1, that element can also be focused
@@ -146,7 +147,7 @@ const Modal: FunctionComponent<ModalProps> = ({
    * when the modal unmounts.
    * */
   useEffect(() => {
-    const listener = (event): void => {
+    const listener = (event: Event): void => {
       // If the modal is not visible, the ref will not be set
       if (!finalForwardRef.current) return;
       const modal: HTMLElement = finalForwardRef.current;
@@ -168,7 +169,7 @@ const Modal: FunctionComponent<ModalProps> = ({
       document.body.style.overflow = '';
       document.body.removeEventListener('focus', listener);
     };
-  }, [isVisible]);
+  }, [finalForwardRef, focusables, isVisible]);
 
   return createPortal((
     <CSSTransition

--- a/src/Modals/Modal.tsx
+++ b/src/Modals/Modal.tsx
@@ -135,6 +135,9 @@ const Modal: FunctionComponent<ModalProps> = ({
   // If the ref is not provided, create one since it is used below
   const finalForwardRef = forwardRef != null ? forwardRef : useRef(null);
 
+  const focusables = 'button, [href], input, select, textarea,'
+            + ' [tabindex]:not([tabindex="-1"])';
+
   /**
    * Watch the isVisible prop, and set the background overflow style when it
    * is opened. We're returning a cleanup function that will reset the style
@@ -144,8 +147,6 @@ const Modal: FunctionComponent<ModalProps> = ({
     const listener = (event): void => {
       const modal: HTMLElement = finalForwardRef.current;
       if (!modal.contains(event.target as Node)) {
-        const focusables = 'button, [href], input, select, textarea,'
-          + ' [tabindex]:not([tabindex="-1"])';
         const firstFocusable: HTMLElement = modal.querySelector(focusables);
         if (firstFocusable != null) {
           firstFocusable.focus();

--- a/src/Modals/Modal.tsx
+++ b/src/Modals/Modal.tsx
@@ -147,6 +147,8 @@ const Modal: FunctionComponent<ModalProps> = ({
    * */
   useEffect(() => {
     const listener = (event): void => {
+      // If the modal is not visible, the ref will not be set
+      if (!finalForwardRef.current) return;
       const modal: HTMLElement = finalForwardRef.current;
       if (!modal.contains(event.target as Node)) {
         const firstFocusable: HTMLElement = modal.querySelector(focusables);

--- a/src/Modals/Modal.tsx
+++ b/src/Modals/Modal.tsx
@@ -135,6 +135,8 @@ const Modal: FunctionComponent<ModalProps> = ({
   // If the ref is not provided, create one since it is used below
   const finalForwardRef = forwardRef != null ? forwardRef : useRef(null);
 
+  // Encompasses all of the elements that can be focused on by the user
+  // If you set the index of an element to -1, that element can also be focused
   const focusables = 'button, [href], input, select, textarea,'
             + ' [tabindex]:not([tabindex="-1"])';
 

--- a/src/Modals/ModalHeader.tsx
+++ b/src/Modals/ModalHeader.tsx
@@ -3,6 +3,7 @@ import React, {
   ReactNode,
   FunctionComponent,
   useContext,
+  Ref,
 } from 'react';
 import styled, { ThemeContext } from 'styled-components';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -21,6 +22,10 @@ interface ModalHeaderProps {
    * rendered
    */
   closeButtonHandler?: () => void;
+  /** Specifies the ref of the Modal Header */
+  forwardRef?: Ref<HTMLHeadingElement>;
+  /** Corresponds to HTML attribute tabindex */
+  tabIndex?: number;
 }
 
 const ModalTitle = styled(SectionHeading)`
@@ -46,11 +51,15 @@ declare type ModalHeader = ReactElement<ModalHeaderProps>;
 const ModalHeader: FunctionComponent<ModalHeaderProps> = ({
   closeButtonHandler,
   children,
+  forwardRef,
+  tabIndex,
 }): ReactElement<ModalHeaderProps> => {
   const markOneTheme = useContext(ThemeContext);
   return (
     <StyledModalHeader
       theme={markOneTheme}
+      ref={forwardRef}
+      tabIndex={tabIndex}
     >
       <ModalTitle>
         {children}

--- a/src/Modals/__tests__/Modal.test.tsx
+++ b/src/Modals/__tests__/Modal.test.tsx
@@ -68,7 +68,7 @@ describe('Modal', function () {
           const [modalVisible, setModalVisible] = useState(false);
           const onButtonClick = () => {
             setModalVisible(true);
-            setTimeout(() => ref.current.focus(), 0);
+            setTimeout(() => ref.current.focus());
           };
           return (
             <>

--- a/src/Modals/__tests__/Modal.test.tsx
+++ b/src/Modals/__tests__/Modal.test.tsx
@@ -10,8 +10,6 @@ import {
   waitForElement,
   BoundFunction,
   GetByRole,
-  GetByText,
-  wait,
 } from 'test-utils';
 import Modal from 'Modals/Modal';
 import { Button } from 'Buttons';
@@ -20,7 +18,6 @@ import { ModalHeader } from 'Modals';
 
 describe('Modal', function () {
   let getByRole: BoundFunction<GetByRole>;
-  let getByText: BoundFunction<GetByText>;
   describe('isVisible prop', function () {
     context('When isVisible is false', function () {
       it('Should not render any visible content', function () {
@@ -100,7 +97,7 @@ describe('Modal', function () {
             </>
           );
         };
-        ({ getByRole, getByText } = render(
+        ({ getByRole } = render(
           <RefExample />
         ));
       });
@@ -114,7 +111,7 @@ describe('Modal', function () {
         const testButton = document.getElementById('testButton') as HTMLButtonElement;
         testButton.click();
         await waitForElement(() => getByRole('heading'));
-        fireEvent.keyPress(getByText('Modal Header'), {key: 'Tab', code: 'Tab'});
+        fireEvent.keyPress(getByRole('heading'), { key: 'Tab', code: 'Tab' });
         strictEqual((document.activeElement as HTMLElement).textContent.includes('Modal Header'), true);
       });
     });

--- a/src/Modals/__tests__/Modal.test.tsx
+++ b/src/Modals/__tests__/Modal.test.tsx
@@ -68,11 +68,9 @@ describe('Modal', function () {
           const [modalVisible, setModalVisible] = useState(false);
           const onButtonClick = () => {
             setModalVisible(true);
-            setTimeout(() => {
-              if (ref.current) {
-                ref.current.focus();
-              }
-            });
+            if (ref.current) {
+              ref.current.focus();
+            };
           };
           return (
             <>

--- a/src/Modals/__tests__/Modal.test.tsx
+++ b/src/Modals/__tests__/Modal.test.tsx
@@ -68,9 +68,11 @@ describe('Modal', function () {
           const [modalVisible, setModalVisible] = useState(false);
           const onButtonClick = () => {
             setModalVisible(true);
-            if (ref.current) {
-              setTimeout(() => ref.current.focus());
-            }
+              setTimeout(() => {
+                if (ref.current) {
+                  ref.current.focus();
+                }
+              });
           };
           return (
             <>

--- a/src/Modals/__tests__/Modal.test.tsx
+++ b/src/Modals/__tests__/Modal.test.tsx
@@ -70,7 +70,7 @@ describe('Modal', function () {
             setModalVisible(true);
             if (ref.current) {
               ref.current.focus();
-            };
+            }
           };
           return (
             <>

--- a/src/Modals/__tests__/Modal.test.tsx
+++ b/src/Modals/__tests__/Modal.test.tsx
@@ -64,11 +64,13 @@ describe('Modal', function () {
     context('when forwardRef prop is present', function () {
       beforeEach(function () {
         const RefExample = () => {
-          const ref = useRef(null);
+          const ref = useRef<HTMLDivElement>(null);
           const [modalVisible, setModalVisible] = useState(false);
           const onButtonClick = () => {
             setModalVisible(true);
-            setTimeout(() => ref.current.focus());
+            if (ref.current) {
+              setTimeout(() => ref.current.focus());
+            }
           };
           return (
             <>

--- a/src/Modals/__tests__/Modal.test.tsx
+++ b/src/Modals/__tests__/Modal.test.tsx
@@ -10,6 +10,8 @@ import {
   waitForElement,
   BoundFunction,
   GetByRole,
+  GetByText,
+  wait,
 } from 'test-utils';
 import Modal from 'Modals/Modal';
 import { Button } from 'Buttons';
@@ -18,6 +20,7 @@ import { ModalHeader } from 'Modals';
 
 describe('Modal', function () {
   let getByRole: BoundFunction<GetByRole>;
+  let getByText: BoundFunction<GetByText>;
   describe('isVisible prop', function () {
     context('When isVisible is false', function () {
       it('Should not render any visible content', function () {
@@ -97,7 +100,7 @@ describe('Modal', function () {
             </>
           );
         };
-        ({ getByRole } = render(
+        ({ getByRole, getByText } = render(
           <RefExample />
         ));
       });
@@ -105,6 +108,13 @@ describe('Modal', function () {
         const testButton = document.getElementById('testButton') as HTMLButtonElement;
         testButton.click();
         await waitForElement(() => getByRole('heading'));
+        strictEqual((document.activeElement as HTMLElement).textContent.includes('Modal Header'), true);
+      });
+      it('will focus back on the first focusable element after cycling through modal elements', async function () {
+        const testButton = document.getElementById('testButton') as HTMLButtonElement;
+        testButton.click();
+        await waitForElement(() => getByRole('heading'));
+        fireEvent.keyPress(getByText('Modal Header'), {key: 'Tab', code: 'Tab'});
         strictEqual((document.activeElement as HTMLElement).textContent.includes('Modal Header'), true);
       });
     });

--- a/src/Modals/__tests__/Modal.test.tsx
+++ b/src/Modals/__tests__/Modal.test.tsx
@@ -68,11 +68,11 @@ describe('Modal', function () {
           const [modalVisible, setModalVisible] = useState(false);
           const onButtonClick = () => {
             setModalVisible(true);
-              setTimeout(() => {
-                if (ref.current) {
-                  ref.current.focus();
-                }
-              });
+            setTimeout(() => {
+              if (ref.current) {
+                ref.current.focus();
+              }
+            });
           };
           return (
             <>

--- a/src/Modals/__tests__/Modal.test.tsx
+++ b/src/Modals/__tests__/Modal.test.tsx
@@ -1,15 +1,13 @@
 import React, { useState, FunctionComponent, useRef } from 'react';
 import { strictEqual } from 'assert';
 import {
-  spy, stub, SinonSpy, SinonStub,
+  stub, SinonStub,
 } from 'sinon';
 import {
   render,
   fireEvent,
-  cleanup,
-  waitForElement,
   BoundFunction,
-  GetByRole,
+  FindByRole,
 } from 'test-utils';
 import Modal from 'Modals/Modal';
 import { Button } from 'Buttons';
@@ -17,7 +15,7 @@ import { VARIANT } from 'Theme';
 import { ModalHeader } from 'Modals';
 
 describe('Modal', function () {
-  let getByRole: BoundFunction<GetByRole>;
+  let findByRole: BoundFunction<FindByRole>;
   describe('isVisible prop', function () {
     context('When isVisible is false', function () {
       it('Should not render any visible content', function () {
@@ -99,21 +97,21 @@ describe('Modal', function () {
             </>
           );
         };
-        ({ getByRole } = render(
+        ({ findByRole } = render(
           <RefExample />
         ));
       });
       it('can be used to shift the focus to the modal header on button click', async function () {
         const testButton = document.getElementById('testButton') as HTMLButtonElement;
         testButton.click();
-        await waitForElement(() => getByRole('heading'));
+        await findByRole('heading');
         strictEqual((document.activeElement as HTMLElement).textContent.includes('Modal Header'), true);
       });
       it('will focus back on the first focusable element after cycling through modal elements', async function () {
         const testButton = document.getElementById('testButton') as HTMLButtonElement;
         testButton.click();
-        await waitForElement(() => getByRole('heading'));
-        fireEvent.keyPress(getByRole('heading'), { key: 'Tab', code: 'Tab' });
+        await findByRole('heading');
+        fireEvent.keyPress(await findByRole('heading'), { key: 'Tab', code: 'Tab' });
         strictEqual((document.activeElement as HTMLElement).textContent.includes('Modal Header'), true);
       });
     });

--- a/src/Modals/__tests__/Modal.test.tsx
+++ b/src/Modals/__tests__/Modal.test.tsx
@@ -64,13 +64,15 @@ describe('Modal', function () {
     context('when forwardRef prop is present', function () {
       beforeEach(function () {
         const RefExample = () => {
-          const ref = useRef<HTMLDivElement>(null);
+          const testRef = useRef<HTMLDivElement>(null);
           const [modalVisible, setModalVisible] = useState(false);
           const onButtonClick = () => {
             setModalVisible(true);
-            if (ref.current) {
-              ref.current.focus();
-            }
+            setTimeout(() => {
+              if (testRef.current) {
+                testRef.current.focus();
+              }
+            });
           };
           return (
             <>
@@ -89,7 +91,7 @@ describe('Modal', function () {
                 <ModalHeader
                   closeButtonHandler={() => { setModalVisible(false); }}
                   tabIndex={0}
-                  forwardRef={ref}
+                  forwardRef={modalVisible ? testRef : null}
                 >
                   Modal Header
                 </ModalHeader>


### PR DESCRIPTION
This pull request adds an optional `forwardRef` prop to the `Modal` and `ModalHeader`. The props specifies the ref of the modal, which is used to direct the focus. When the user clicks on the button to open the Modal, the focus should shift to the modal's header for accessibility purposes. This PR adds logic to redirect the focus to the first focusable element in the modal when the modal is visible, and it also traps the focus in the modal when the modal is visible.

## Types of changes
<!--
  What types of changes does your code introduce? Put an `x` in all the boxes
  that apply:
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
<!--
  Go over all the following points, and put an `x` in all the boxes that apply.
-->
- [x] I have run `eslint` on the code
- [x] I have added JSDoc for all of my code (where applicable)
- [x] I have added tests to cover my changes.

## Priority:
- [x] Normal <!-- New piece of functionality -->
- [ ] High <!-- Critical bug requiring urgent review -->

## Related Issues:
<!--
  Add the issue number in below that this PR is intended to address.

  Also mention any issues that this PR is related to, and if possible,
  provide more information regarding the relationship to the issues in
  question (i.e does the PR fix the issue, is it designed to fix another bug
  that is similar to the issue etc.)
-->
Addresses [#235](https://github.com/seas-computing/course-planner/issues/235)

<!--
  Attribution:
  PR Template adapted from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->