### PR TITLE
Fix absolute paths

### DIFF
--- a/src/Forms/Dropdown.tsx
+++ b/src/Forms/Dropdown.tsx
@@ -6,7 +6,7 @@ import React, {
   Ref,
 } from 'react';
 import styled, { ThemeContext } from 'styled-components';
-import { fromTheme } from 'Theme';
+import { fromTheme } from '../Theme';
 import ValidationErrorMessage from './ValidationErrorMessage';
 import Label, { POSITION } from './Label';
 

--- a/src/Forms/Label.tsx
+++ b/src/Forms/Label.tsx
@@ -4,7 +4,7 @@ import React, {
   FunctionComponent,
 } from 'react';
 import styled, { ThemeContext } from 'styled-components';
-import { fromTheme } from 'Theme';
+import { fromTheme } from '../Theme';
 
 /** An enum that represents the possible values for the label's positioning */
 export enum POSITION {

--- a/src/Forms/TextInput.tsx
+++ b/src/Forms/TextInput.tsx
@@ -6,7 +6,7 @@ import React, {
   Ref,
 } from 'react';
 import styled, { ThemeContext } from 'styled-components';
-import { fromTheme } from 'Theme';
+import { fromTheme } from '../Theme';
 import ValidationErrorMessage from './ValidationErrorMessage';
 import Label, { POSITION } from './Label';
 

--- a/src/Forms/ValidationErrorMessage.tsx
+++ b/src/Forms/ValidationErrorMessage.tsx
@@ -2,7 +2,7 @@ import React, {
   ReactNode, FunctionComponent, ReactElement, useContext,
 } from 'react';
 import styled, { ThemeContext } from 'styled-components';
-import { fromTheme } from 'Theme';
+import { fromTheme } from '../Theme';
 
 export interface ValidationErrorMessageProps {
   /** Text or components to be displayed */

--- a/src/Forms/__tests__/TextInput.test.tsx
+++ b/src/Forms/__tests__/TextInput.test.tsx
@@ -11,7 +11,7 @@ import { spy, SinonSpy } from 'sinon';
 import { strictEqual } from 'assert';
 import userEvent from '@testing-library/user-event';
 import { Button } from 'Buttons';
-import { VARIANT } from 'Theme';
+import { VARIANT } from '../../Theme';
 import TextInput from '../TextInput';
 
 enum POSITION {

--- a/src/Icons/IconLink.tsx
+++ b/src/Icons/IconLink.tsx
@@ -3,7 +3,7 @@ import React, {
 } from 'react';
 import styled, { ThemeContext } from 'styled-components';
 import { FontAwesomeIconProps } from '@fortawesome/react-fontawesome';
-import { fromTheme } from 'Theme';
+import { fromTheme } from '../Theme';
 
 export interface IconLinkProps {
   /** Function to call on click event */

--- a/src/Layout/PageBody.tsx
+++ b/src/Layout/PageBody.tsx
@@ -1,6 +1,6 @@
 import { ReactNode, ReactElement } from 'react';
 import styled, { withTheme } from 'styled-components';
-import { fromTheme } from 'Theme';
+import { fromTheme } from '../Theme';
 
 export interface PageBodyProps {
   /** Page contents */

--- a/src/Links/Link.tsx
+++ b/src/Links/Link.tsx
@@ -8,7 +8,7 @@ import {
   Link as ReactLink,
   LinkProps,
 } from 'react-router-dom';
-import { fromTheme, VARIANT } from 'Theme';
+import { fromTheme, VARIANT } from '../Theme';
 
 const StyledLink = styled(ReactLink)`
   text-decoration: none;

--- a/src/Spinners/LoadSpinner.tsx
+++ b/src/Spinners/LoadSpinner.tsx
@@ -4,7 +4,7 @@ import React, {
 import styled, { ThemeContext } from 'styled-components';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCircleNotch } from '@fortawesome/free-solid-svg-icons';
-import { fromTheme, VARIANT } from 'Theme';
+import { fromTheme, VARIANT } from '../Theme';
 import LoadSpinnerText, { SPINNER_TEXT } from './LoadSpinnerText';
 
 export interface LoadSpinnerProps {

--- a/src/Spinners/LoadSpinnerText.tsx
+++ b/src/Spinners/LoadSpinnerText.tsx
@@ -2,7 +2,7 @@ import React, {
   FunctionComponent, ReactElement, useContext,
 } from 'react';
 import styled, { ThemeContext } from 'styled-components';
-import { fromTheme } from 'Theme';
+import { fromTheme } from '../Theme';
 
 export enum SPINNER_TEXT {
   LIGHT = 'light',

--- a/src/Tables/TableBody.tsx
+++ b/src/Tables/TableBody.tsx
@@ -1,6 +1,6 @@
 import { ReactElement, ForwardRefExoticComponent } from 'react';
 import styled from 'styled-components';
-import { fromTheme } from 'Theme';
+import { fromTheme } from '../Theme';
 import TableRow from './TableRow';
 
 export interface TableBodyProps {

--- a/src/Tables/TableCell.tsx
+++ b/src/Tables/TableCell.tsx
@@ -1,6 +1,6 @@
 import { ReactNode, ReactElement, ForwardRefExoticComponent } from 'react';
 import styled from 'styled-components';
-import { fromTheme } from 'Theme';
+import { fromTheme } from '../Theme';
 
 /** Represents the possible values for TableCell's text-align property */
 export enum ALIGN {

--- a/src/Tables/TableCellListItem.tsx
+++ b/src/Tables/TableCellListItem.tsx
@@ -1,6 +1,6 @@
 import { ReactElement, ReactNode } from 'react';
 import styled from 'styled-components';
-import { fromTheme } from 'Theme';
+import { fromTheme } from '../Theme';
 
 export interface TableCellListItemProps {
   /**

--- a/src/Tables/TableHead.tsx
+++ b/src/Tables/TableHead.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 import { ReactElement, ForwardRefExoticComponent } from 'react';
-import { fromTheme } from 'Theme';
+import { fromTheme } from '../Theme';
 import TableRow from './TableRow';
 
 export interface TableHeadProps {

--- a/src/Tables/TableHeadingCell.tsx
+++ b/src/Tables/TableHeadingCell.tsx
@@ -5,7 +5,7 @@ import {
   ForwardRefExoticComponent,
 } from 'react';
 import styled from 'styled-components';
-import { fromTheme } from 'Theme';
+import { fromTheme } from '../Theme';
 
 export interface TableHeadingCellProps {
   /** Specifies the background color of the table cell */

--- a/src/Tables/TableRowHeadingCell.tsx
+++ b/src/Tables/TableRowHeadingCell.tsx
@@ -3,7 +3,7 @@ import {
 } from 'react';
 import styled from 'styled-components';
 import { ALIGN, VALIGN } from './TableCell';
-import { fromTheme } from '../Theme/utils';
+import { fromTheme } from '../Theme';
 
 export interface TableRowHeadingCellProps {
   /** Allows you to pass in a alignment property from the ALIGN enum */

--- a/src/Tabs/TabList.tsx
+++ b/src/Tabs/TabList.tsx
@@ -2,7 +2,7 @@ import {
   ReactElement,
 } from 'react';
 import styled, { withTheme } from 'styled-components';
-import { fromTheme } from 'Theme';
+import { fromTheme } from '../Theme';
 import TabListItem from './TabListItem';
 
 export interface TabListProps {

--- a/src/Tabs/TabListItem.tsx
+++ b/src/Tabs/TabListItem.tsx
@@ -2,7 +2,7 @@ import React, {
   ReactElement, ReactNode, FunctionComponent, useContext,
 } from 'react';
 import styled, { ThemeContext } from 'styled-components';
-import { fromTheme } from 'Theme';
+import { fromTheme } from '../Theme';
 
 export interface TabListItemProps {
   /** Text or components to be displayed in the TabList item */


### PR DESCRIPTION
The absolute import for Theme doesn't work when the package is installed in an app. This has been happening when my editor auto-imports packages, so I'll need to fix that, or explore how we can add some kind of check for this.

Apologies for the inconvenience.