### PR TITLE
Split sublevel theme types into new file

### DIFF
--- a/src/Theme/ThemeTypes.ts
+++ b/src/Theme/ThemeTypes.ts
@@ -1,0 +1,58 @@
+export type ColorRange = {
+  light: string;
+  medium: string;
+  subtle?: string;
+  dark: string;
+  darker?: string;
+  accent?: string;
+};
+
+export type FontSpec = {
+  family?: string;
+  size?: string;
+  weight?: string;
+  color?: string;
+};
+
+export type AcademicArea = 'acs' |
+'am' |
+'ap' |
+'be' |
+'cs' |
+'ee' |
+'ese' |
+'general' |
+'mat & me' |
+'mde' |
+'msmba' |
+'sem';
+
+export type ColorCategory = 'background' | 'text' | 'area';
+
+export type FontCategory = 'base' |
+'body' |
+'data' |
+'note' |
+'bold' |
+'title'|
+'heading' |
+'error';
+
+export type WhiteSpaceSize = 'zero' |
+'xsmall' |
+'small' |
+'medium' |
+'large' |
+'xlarge';
+
+export type BorderWeight = 'hairline' | 'light' | 'heavy';
+
+export type ShadowWeight = 'xlight' | 'light' | 'medium';
+
+export type TextColors = 'base' |
+'light' |
+'medium' |
+'dark' |
+'info' |
+'positive' |
+'negative';

--- a/src/Theme/utils.ts
+++ b/src/Theme/utils.ts
@@ -1,4 +1,27 @@
-import { ValidThemeValues, DefaultTheme } from 'styled-components';
+import { DefaultTheme } from 'styled-components';
+import {
+  ColorRange,
+  TextColors,
+  AcademicArea,
+  FontCategory,
+  ShadowWeight,
+  BorderWeight,
+  WhiteSpaceSize,
+  FontSpec,
+  ColorCategory,
+} from './ThemeTypes';
+
+type ValidThemeValues = keyof DefaultTheme |
+keyof ColorRange |
+keyof FontSpec |
+AcademicArea |
+ColorCategory |
+FontCategory |
+ShadowWeight |
+BorderWeight |
+WhiteSpaceSize |
+TextColors |
+VARIANT;
 
 /**
  * Recursively get a value from the theme object, or return null if the value

--- a/src/styled.d.ts
+++ b/src/styled.d.ts
@@ -1,67 +1,17 @@
 import 'styled-components';
 import { VARIANT } from './Theme/utils';
+import {
+  ColorRange,
+  TextColors,
+  AcademicArea,
+  FontCategory,
+  ShadowWeight,
+  BorderWeight,
+  WhiteSpaceSize,
+  FontSpec,
+} from './Theme/ThemeTypes';
 
 declare module 'styled-components' {
-
-  type ColorRange = {
-    light: string;
-    medium: string;
-    subtle?: string;
-    dark: string;
-    darker?: string;
-    accent?: string;
-  };
-
-  type FontSpec = {
-    family?: string;
-    size?: string;
-    weight?: string;
-    color?: string;
-  };
-
-  type AcademicArea = 'acs' |
-  'am' |
-  'ap' |
-  'be' |
-  'cs' |
-  'ee' |
-  'ese' |
-  'general' |
-  'mat & me' |
-  'mde' |
-  'msmba' |
-  'sem';
-
-  type ColorCategory = 'background' | 'text' | 'area';
-
-  type FontCategory = 'base' |
-  'body' |
-  'data' |
-  'note' |
-  'bold' |
-  'title'|
-  'heading' |
-  'error';
-
-  type WhiteSpaceSize = 'zero' |
-  'xsmall' |
-  'small' |
-  'medium' |
-  'large' |
-  'xlarge';
-
-  type BorderWeight = 'hairline' | 'light' | 'heavy';
-
-  type ShadowWeight = 'xlight' | 'light' | 'medium';
-
-  type TextColors = 'base' |
-  'light' |
-  'medium' |
-  'dark' |
-  'info' |
-  'positive' |
-  'negative';
-
   export interface DefaultTheme {
     color: {
       background:{
@@ -90,16 +40,4 @@ declare module 'styled-components' {
       [key in WhiteSpaceSize]: string
     };
   }
-
-  export type ValidThemeValues = keyof DefaultTheme |
-  keyof ColorRange |
-  keyof FontSpec |
-  AcademicArea |
-  ColorCategory |
-  FontCategory |
-  ShadowWeight |
-  BorderWeight |
-  WhiteSpaceSize |
-  TextColors |
-  VARIANT;
 }


### PR DESCRIPTION
The existing method of declaring all the theme types as part of the styled-components namespace was breaking when the library was published, since none of those themes were being exported and thus were missing when Theme/utils.ts tried to import them. This moves those sub-levels into the ThemeTypes.ts file (which will be compiled/exported), then declares the ValidThemeValues as part of the utils module itself.

As a quick and dirty way to test the compiled mark-one with course planner:

In local version of mark-one:
1. Remove any existing lib directory: `rm -rf ./lib`
2. compile the code: `npm run prepublishOnly`

In course-planner:
1. run `npm install` 
2. remove the existing lib directory from the installed version of mark-one: `rm -rf node_modules/mark-one/lib`
3. copy the built version of mark-one into node_modules: `cp -r /path/to/mark-one/lib node_modules/mark-one/lib`

Related to seas-computing/course-planner#242
