### PR TITLE
Solve for Modal Content Overflow

### DIFF
--- a/examples/Modals/ModalBody.md
+++ b/examples/Modals/ModalBody.md
@@ -28,3 +28,116 @@ const [modalVisible, setModalVisible] = useState(false);
 </>
 ```
 
+Overflow example: When the contents of the modal body exceeds the height of the page, the user can scroll to see the full contents of the modal.
+```jsx
+import { useState } from 'react';
+import { Button, ModalHeader, Modal, Fieldset, Checkbox } from 'mark-one';
+
+const [modalVisible, setModalVisible] = useState(false);
+
+<>
+  <Button
+    id="overflowTestButton"
+    onClick={() => {setModalVisible(true)}}
+  >
+    Open Modal
+  </Button>
+  <Modal
+    ariaLabelledBy="overflowTestButton"
+    closeHandler={() => {setModalVisible(false)}}
+    isVisible={modalVisible}
+  >
+    <ModalHeader>Overflow Example</ModalHeader>
+    <ModalBody>
+      <>
+        <Fieldset
+          legend="Fieldset Legend"
+          isBorderVisible={false}
+          isLegendVisible={false}
+        >
+          <Checkbox
+          label="Option 1"
+          disabled
+          checked
+          />
+          <Checkbox
+          label="Option 2"
+          disabled
+          checked
+          />
+          <Checkbox
+          label="Option 3"
+          disabled
+          checked
+          />
+          <Checkbox
+          label="Option 4"
+          disabled
+          checked
+          />
+          <Checkbox
+          label="Option 5"
+          disabled
+          checked
+          />
+          <Checkbox
+          label="Option 6"
+          disabled
+          checked
+          />
+          <Checkbox
+          label="Option 7"
+          disabled
+          checked
+          />
+          <Checkbox
+          label="Option 8"
+          disabled
+          checked
+          />
+          <Checkbox
+          label="Option 9"
+          disabled
+          checked
+          />
+          <Checkbox
+          label="Option 10"
+          disabled
+          checked
+          />
+          <Checkbox
+          label="Option 11"
+          disabled
+          checked
+          />
+          <Checkbox
+          label="Option 12"
+          disabled
+          checked
+          />
+          <Checkbox
+          label="Option 13"
+          disabled
+          checked
+          />
+          <Checkbox
+          label="Option 14"
+          disabled
+          checked
+          />
+          <Checkbox
+          label="Option 15"
+          disabled
+          checked
+          />
+        </Fieldset>
+      </>
+      <Button onClick={() => setModalVisible(false)}>
+        Close Modal
+      </Button>
+    </ModalBody>
+  </Modal>
+</>
+```
+
+

--- a/src/Modals/ModalBody.tsx
+++ b/src/Modals/ModalBody.tsx
@@ -10,7 +10,7 @@ interface ModalBodyProps {
 
 const StyledModalBody = styled.div<ModalBodyProps>`
   padding: ${({ theme }): string => theme.ws.medium};
-  overflow: scroll;
+  overflow: auto;
 `;
 
 /**

--- a/src/Modals/ModalBody.tsx
+++ b/src/Modals/ModalBody.tsx
@@ -10,6 +10,7 @@ interface ModalBodyProps {
 
 const StyledModalBody = styled.div<ModalBodyProps>`
   padding: ${({ theme }): string => theme.ws.medium};
+  overflow: scroll;
 `;
 
 /**


### PR DESCRIPTION
This PR adds the CSS property `overflow` to the `ModalBody` so that if the modal contents are larger than the modal itself, the user will be able to scroll through the contents. I added the CSS property to the body instead of the overall modal component so that the title of the modal would be 'sticky' and could always be seen.

## Types of changes
<!--
  What types of changes does your code introduce? Put an `x` in all the boxes
  that apply:
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
<!--
  Go over all the following points, and put an `x` in all the boxes that apply.
-->
- [x] I have run `eslint` on the code
- [x] I have added JSDoc for all of my code (where applicable)
- [ ] I have added tests to cover my changes.

## Priority:
- [x] Normal <!-- New piece of functionality -->
- [ ] High <!-- Critical bug requiring urgent review -->

## Related Issues:
<!--
  Add the issue number in below that this PR is intended to address.

  Also mention any issues that this PR is related to, and if possible,
  provide more information regarding the relationship to the issues in
  question (i.e does the PR fix the issue, is it designed to fix another bug
  that is similar to the issue etc.)
-->
Addresses [#235](https://github.com/seas-computing/course-planner/issues/235)

<!--
  Attribution:
  PR Template adapted from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->