### PR TITLE
Create ExternalLink component

### DIFF
--- a/examples/Links/ExternalLink.md
+++ b/examples/Links/ExternalLink.md
@@ -1,0 +1,12 @@
+This component is a styled version of a regular `<a>` link, for use when we need to link to external resources.
+
+```jsx
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faSignOutAlt } from '@fortawesome/free-solid-svg-icons';
+
+<ExternalLink href="https://key.harvard.edu/logout">
+  Log Out
+  {' '}
+  <FontAwesomeIcon icon={faSignOutAlt} />
+</ExternalLink>
+```

--- a/src/Links/ExternalLink.tsx
+++ b/src/Links/ExternalLink.tsx
@@ -1,0 +1,18 @@
+import styled from 'styled-components';
+import { fromTheme, VARIANT } from '../Theme';
+
+/**
+ * A default <a> element with styles mirroring the Link component
+ */
+export default styled.a`
+  text-decoration: none;
+  color: ${fromTheme('color', 'background', VARIANT.INFO, 'medium')};
+  &:hover {
+    text-decoration: underline;
+    color: ${fromTheme('color', 'background', VARIANT.INFO, 'dark')};
+  }
+  &:visited {
+    text-decoration: none;
+    color: ${fromTheme('color', 'background', VARIANT.INFO, 'medium')};
+  }
+`;

--- a/src/Links/index.ts
+++ b/src/Links/index.ts
@@ -1,1 +1,2 @@
 export { default as Link } from './Link';
+export { default as ExternalLink } from './ExternalLink';


### PR DESCRIPTION
Our existing Link component is a wrapper around ReactRouter's Link, so we can only use it for navigation within the app. This ExternalLink is just a `styled.a` with CSS to match the Link, so that we can create links to external pages that look similar.

The specific use case for this is the "log out" link from #246