### PR TITLE
Feature/224 add hide error prop to input text label

### DIFF
--- a/examples/Forms/TextInput.md
+++ b/examples/Forms/TextInput.md
@@ -72,7 +72,6 @@ const [value, setValue] = useState('Some valid input');
   }}
 />
 ```
-
 Text Input example: The `disabled` prop set to `true.`
 
 ```jsx
@@ -104,6 +103,48 @@ const [value, setValue] = useState('Some valid input');
   name="example"
   id="example"
   label="Description:"
+  onChange={(event) => {
+    setValue(event.target.value);
+  }}
+/>
+```
+
+Label example: The optional `errorMessage` prop is not set, and the 
+`hideError` prop is set to `true.` Remove the `errorMesage` style.
+
+```jsx
+import { useState } from 'react';
+
+const [value, setValue] = useState('Some valid input');
+
+<TextInput
+  value={value}
+  name="example"
+  id="example"
+  label="Description:"
+  hideError={true}
+  onChange={(event) => {
+    setValue(event.target.value);
+  }}
+/>
+```
+
+Label example: The optional `errorMessage` prop is set, and the 
+`hideError` prop is set to `true.` Remove the `errorMesage` and
+its style.
+
+```jsx
+import { useState } from 'react';
+
+const [value, setValue] = useState('Some valid input');
+
+<TextInput
+  value={value}
+  name="example"
+  id="example"
+  label="Description:"
+  errorMessage="Error: Please enter a valid ID"
+  hideError={true}
   onChange={(event) => {
     setValue(event.target.value);
   }}

--- a/examples/Forms/TextInput.md
+++ b/examples/Forms/TextInput.md
@@ -110,7 +110,7 @@ const [value, setValue] = useState('Some valid input');
 ```
 
 Label example: The optional `errorMessage` prop is not set, and the 
-`hideError` prop is set to `true.` Remove the `errorMesage` style.
+`hideError` prop is set to `true`, which removes the errorMessage style.
 
 ```jsx
 import { useState } from 'react';
@@ -130,8 +130,8 @@ const [value, setValue] = useState('Some valid input');
 ```
 
 Label example: The optional `errorMessage` prop is set, and the 
-`hideError` prop is set to `true.` Remove the `errorMesage` and
-its style.
+`hideError` prop is set to `true`, which removes the errorMessage 
+and its style.
 
 ```jsx
 import { useState } from 'react';

--- a/examples/Forms/TextInput.md
+++ b/examples/Forms/TextInput.md
@@ -74,6 +74,7 @@ const [value, setValue] = useState('Some valid input');
   }}
 />
 ```
+
 Text Input example: The `disabled` prop set to `true.`
 
 ```jsx
@@ -105,6 +106,46 @@ const [value, setValue] = useState('Some valid input');
   name="example"
   id="example"
   label="Description:"
+  onChange={(event) => {
+    setValue(event.target.value);
+  }}
+/>
+```
+
+Error Message example: The optional `errorMessage` property is set, and the `labelPosition` prop defaults to `POSITION.LEFT.`
+
+```jsx
+import { useState } from 'react';
+
+const [value, setValue] = useState('Invalid value');
+
+<TextInput
+  value={value}
+  name="example"
+  id="example"
+  errorMessage="Error: Please enter a valid ID"
+  label="Description:"
+  onChange={(event) => {
+    setValue(event.target.value);
+  }}
+/>
+```
+
+Error Message example: The optional `errorMessage` property is set, and the `labelPosition` prop is set to `POSITION.TOP.`
+
+```jsx
+import { useState } from 'react';
+import { POSITION } from 'mark-one';
+
+const [value, setValue] = useState('Invalid value');
+
+<TextInput
+  value={value}
+  name="example"
+  id="example"
+  errorMessage="Error: Please enter a valid ID"
+  label="Description:"
+  labelPosition={POSITION.TOP}
   onChange={(event) => {
     setValue(event.target.value);
   }}
@@ -147,46 +188,6 @@ const [value, setValue] = useState('Some valid input');
   label="Description:"
   errorMessage="Error: Please enter a valid ID"
   hideError={true}
-  onChange={(event) => {
-    setValue(event.target.value);
-  }}
-/>
-```
-
-Error Message example: The optional `errorMessage` property is set, and the `labelPosition` prop defaults to `POSITION.LEFT.`
-
-```jsx
-import { useState } from 'react';
-
-const [value, setValue] = useState('Invalid value');
-
-<TextInput
-  value={value}
-  name="example"
-  id="example"
-  errorMessage="Error: Please enter a valid ID"
-  label="Description:"
-  onChange={(event) => {
-    setValue(event.target.value);
-  }}
-/>
-```
-
-Error Message example: The optional `errorMessage` property is set, and the `labelPosition` prop is set to `POSITION.TOP.`
-
-```jsx
-import { useState } from 'react';
-import { POSITION } from 'mark-one';
-
-const [value, setValue] = useState('Invalid value');
-
-<TextInput
-  value={value}
-  name="example"
-  id="example"
-  errorMessage="Error: Please enter a valid ID"
-  label="Description:"
-  labelPosition={POSITION.TOP}
   onChange={(event) => {
     setValue(event.target.value);
   }}

--- a/src/Forms/InputLabel.tsx
+++ b/src/Forms/InputLabel.tsx
@@ -85,12 +85,11 @@ const StyledInputLabel = styled.label<StyledInputLabelProps>`
     generateGrid(labelPosition, isLabelVisible)
   )};
   align-items: baseline;
-  gap: ${({ hideError, isLabelVisible, theme }) => {
-    if (!(isLabelVisible) && hideError) {
-      return ('0px');
-    }
-    return ((theme.ws.xsmall) + ' ' + (theme.ws.xsmall));
-  }};
+  gap: ${({ hideError, isLabelVisible, theme }) => (
+    (!isLabelVisible && hideError)
+      ? '0px'
+      : (theme.ws.xsmall) + ' ' + (theme.ws.xsmall)
+  )};
 `;
 
 const StyledInputLabelText = styled.span<StyledInputLabelTextProps>`

--- a/src/Forms/InputLabel.tsx
+++ b/src/Forms/InputLabel.tsx
@@ -35,7 +35,7 @@ export interface StyledInputLabelTextProps {
   labelPosition?: InputLabelPosition;
   /** Used to style label text in a different style if disabled is true */
   disabled?: boolean;
-  /** If true, remove the margin on the StyledLabelProps */
+  /** If true, hide the error Msg and change the style StyledLabelProps */
   hideError?: boolean;
 }
 
@@ -52,7 +52,7 @@ export interface InputLabelProps {
   isRequired?: boolean;
   /** Used to style label text in a different style if disabled is true */
   disabled?: boolean;
-  /** If true, remove the margin on the StyledLabelProps */
+  /** If true, hide the error Msg and change the style StyledLabelProps */
   hideError?: boolean;
 }
 
@@ -84,20 +84,9 @@ const StyledInputLabel = styled.label<StyledInputLabelProps>`
   grid-template-areas: ${({ labelPosition, isLabelVisible }) => (
     generateGrid(labelPosition, isLabelVisible)
   )};
-  margin: ${({ hideError, isLabelVisible, label }) => {
-    if (!(isLabelVisible && label) && hideError) {
-      return ('0px');
-    }
-    return (fromTheme('ws', 'small'));
-  }};
   align-items: baseline;
-  gap: ${({
-    hideError,
-    isLabelVisible,
-    label,
-    theme,
-  }) => {
-    if (!(isLabelVisible && label) && hideError) {
+  gap: ${({ hideError, isLabelVisible, theme }) => {
+    if (!(isLabelVisible) && hideError) {
       return ('0px');
     }
     return ((theme.ws.xsmall) + ' ' + (theme.ws.xsmall));

--- a/src/Forms/Label.tsx
+++ b/src/Forms/Label.tsx
@@ -14,6 +14,8 @@ export enum POSITION {
 }
 
 export interface StyledLabelProps {
+  /** Specifies the label text */
+  label: string;
   /** If true, label will be visible */
   isLabelVisible?: boolean;
   /** Allows you to pass in a label position property from the POSITION enum */
@@ -76,20 +78,32 @@ const generateGrid = (
 const StyledLabel = styled.label<StyledLabelProps>`
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  grid-template-rows: 1fr minmax(1em, max-content);
+  grid-template-rows: ${({ hideError }) => (
+    (hideError)
+      ? '1fr'
+      : '1fr minmax(1em, max-content)'
+  )};
   grid-template-areas: ${({ labelPosition, isLabelVisible }) => (
     generateGrid(labelPosition, isLabelVisible)
   )};
-  margin: ${fromTheme('ws', 'small')};
+  margin: ${({ hideError, isLabelVisible, label }) => {
+    if (!(isLabelVisible && label) && hideError) {
+      return ('0px');
+    }
+    return (fromTheme('ws', 'small'));
+  }};
   align-items: baseline;
-  gap: ${({ theme }) => (theme.ws.xsmall) + ' ' + (theme.ws.xsmall)};
-  ${({ hideError }) => (hideError
-    ? `margin: 0px;
-       gap: 0px;
-       grid-template-rows: 1fr;
-      `
-    : null
-  )};
+  gap: ${({
+    hideError,
+    isLabelVisible,
+    label,
+    theme,
+  }) => {
+    if (!(isLabelVisible && label) && hideError) {
+      return ('0px');
+    }
+    return ((theme.ws.xsmall) + ' ' + (theme.ws.xsmall));
+  }};
 `;
 
 const StyledLabelText = styled.span<StyledLabelTextProps>`
@@ -124,6 +138,7 @@ const Label: FunctionComponent<LabelProps> = (props): ReactElement => {
   const theme = useContext(ThemeContext);
   return (
     <StyledLabel
+      label={label}
       htmlFor={htmlFor}
       labelPosition={labelPosition}
       theme={theme}

--- a/src/Forms/Label.tsx
+++ b/src/Forms/Label.tsx
@@ -80,9 +80,16 @@ const StyledLabel = styled.label<StyledLabelProps>`
   grid-template-areas: ${({ labelPosition, isLabelVisible }) => (
     generateGrid(labelPosition, isLabelVisible)
   )};
-  margin: ${({ hideError }) => (hideError ? 0 : fromTheme('ws', 'small'))};
+  margin: ${fromTheme('ws', 'small')}
   align-items: baseline;
   gap: ${({ theme }) => (theme.ws.xsmall) + ' ' + (theme.ws.xsmall)};
+  ${({ hideError }) => (hideError 
+    ? `margin: 0px;
+       gap: 0px;
+       grid-template-rows: 1fr;
+      `
+    : null
+  )};
 `;
 
 const StyledLabelText = styled.span<StyledLabelTextProps>`
@@ -142,11 +149,13 @@ Label.defaultProps = {
   labelPosition: POSITION.LEFT,
   isLabelVisible: true,
   disabled: false,
+  hideError: false,
 };
 
 StyledLabel.defaultProps = {
   labelPosition: POSITION.LEFT,
   isLabelVisible: true,
+  hideError: false,
 };
 
 export default Label;

--- a/src/Forms/Label.tsx
+++ b/src/Forms/Label.tsx
@@ -80,7 +80,7 @@ const StyledLabel = styled.label<StyledLabelProps>`
   grid-template-areas: ${({ labelPosition, isLabelVisible }) => (
     generateGrid(labelPosition, isLabelVisible)
   )};
-  margin: ${fromTheme('ws', 'small')}
+  margin: ${fromTheme('ws', 'small')};
   align-items: baseline;
   gap: ${({ theme }) => (theme.ws.xsmall) + ' ' + (theme.ws.xsmall)};
   ${({ hideError }) => (hideError

--- a/src/Forms/Label.tsx
+++ b/src/Forms/Label.tsx
@@ -20,6 +20,8 @@ export interface StyledLabelProps {
   labelPosition?: POSITION;
   /** Specifies the id for the label */
   htmlFor: string;
+  /** If true, remove the margin on the StyledLabelProps */
+  hideError?: boolean;
 }
 
 export interface StyledLabelTextProps {
@@ -29,6 +31,8 @@ export interface StyledLabelTextProps {
   labelPosition?: POSITION;
   /** Used to style label text in a different style if disabled is true */
   disabled?: boolean;
+  /** If true, remove the margin on the StyledLabelProps */
+  hideError?: boolean;
 }
 
 export interface LabelProps {
@@ -44,6 +48,8 @@ export interface LabelProps {
   isRequired?: boolean;
   /** Used to style label text in a different style if disabled is true */
   disabled?: boolean;
+  /** If true, remove the margin on the StyledLabelProps */
+  hideError?: boolean;
 }
 
 const generateGrid = (
@@ -74,7 +80,7 @@ const StyledLabel = styled.label<StyledLabelProps>`
   grid-template-areas: ${({ labelPosition, isLabelVisible }) => (
     generateGrid(labelPosition, isLabelVisible)
   )};
-  margin: ${fromTheme('ws', 'small')};
+  margin: ${({ hideError }) => (hideError ? 0 : fromTheme('ws', 'small'))};
   align-items: baseline;
   gap: ${({ theme }) => (theme.ws.xsmall) + ' ' + (theme.ws.xsmall)};
 `;
@@ -106,6 +112,7 @@ const Label: FunctionComponent<LabelProps> = (props): ReactElement => {
     children,
     isRequired,
     disabled,
+    hideError,
   } = props;
   const theme = useContext(ThemeContext);
   return (
@@ -114,6 +121,7 @@ const Label: FunctionComponent<LabelProps> = (props): ReactElement => {
       labelPosition={labelPosition}
       theme={theme}
       isLabelVisible={isLabelVisible}
+      hideError={hideError}
     >
       <StyledLabelText
         isLabelVisible={isLabelVisible}

--- a/src/Forms/Label.tsx
+++ b/src/Forms/Label.tsx
@@ -83,7 +83,7 @@ const StyledLabel = styled.label<StyledLabelProps>`
   margin: ${fromTheme('ws', 'small')}
   align-items: baseline;
   gap: ${({ theme }) => (theme.ws.xsmall) + ' ' + (theme.ws.xsmall)};
-  ${({ hideError }) => (hideError 
+  ${({ hideError }) => (hideError
     ? `margin: 0px;
        gap: 0px;
        grid-template-rows: 1fr;

--- a/src/Forms/TextInput.tsx
+++ b/src/Forms/TextInput.tsx
@@ -39,7 +39,7 @@ export interface TextInputProps {
   isRequired?: boolean;
   /** Specifies the ref of the text input */
   forwardRef?: Ref<HTMLInputElement>;
-  /** If true, ommit the margin style in label */
+  /** If true, omit the margin style in label */
   hideError?: boolean;
 }
 

--- a/src/Forms/TextInput.tsx
+++ b/src/Forms/TextInput.tsx
@@ -39,6 +39,8 @@ export interface TextInputProps {
   isRequired?: boolean;
   /** Specifies the ref of the text input */
   forwardRef?: Ref<HTMLInputElement>;
+  /** If true, ommit the margin style in label */
+  hideError?: boolean;
 }
 
 const StyledTextInput = styled.input<TextInputProps>`
@@ -68,6 +70,7 @@ const TextInput: FunctionComponent<TextInputProps> = (props): ReactElement => {
     isLabelVisible,
     isRequired,
     forwardRef,
+    hideError,
   } = props;
   const theme = useContext(ThemeContext);
   return (
@@ -77,6 +80,7 @@ const TextInput: FunctionComponent<TextInputProps> = (props): ReactElement => {
       labelPosition={labelPosition}
       isLabelVisible={isLabelVisible}
       isRequired={isRequired}
+      hideError={hideError}
     >
       <StyledTextInput
         onChange={onChange}

--- a/src/Forms/TextInput.tsx
+++ b/src/Forms/TextInput.tsx
@@ -97,7 +97,7 @@ const TextInput: FunctionComponent<TextInputProps> = (props): ReactElement => {
         aria-required={isRequired}
         ref={forwardRef}
       />
-      {errorMessage
+      {errorMessage && !hideError
       && (
         <ValidationErrorMessage id={`${id}-error`}>
           {errorMessage}
@@ -112,6 +112,7 @@ TextInput.defaultProps = {
   disabled: false,
   labelPosition: POSITION.LEFT,
   isLabelVisible: true,
+  hideError: false,
 };
 
 /** @component */

--- a/src/Forms/__tests__/TextInput.test.tsx
+++ b/src/Forms/__tests__/TextInput.test.tsx
@@ -72,6 +72,50 @@ describe('Text input', function () {
       strictEqual(error.id, `${inputId}-error`);
     });
   });
+  context('when hideError prop is set to true', function () {
+    beforeEach(function () {
+      changeSpy = spy();
+      ({ queryByText, getByText } = render(
+        <TextInput
+          id="semester"
+          name="semester"
+          value="Spring"
+          label="semester"
+          errorMessage="Error: Please enter a valid ID"
+          hideError
+          onChange={changeSpy}
+        />
+      ));
+    });
+    it('renders', function () {
+      const inputElement = document.getElementById('semester') as HTMLInputElement;
+      strictEqual(!!inputElement, true);
+    });
+    it('calls the change handler when changed', function () {
+      fireEvent.change(document.getElementById('semester'), {
+        target: {
+          value: 'Fall',
+        },
+      });
+      strictEqual(changeSpy.callCount, 1);
+    });
+    it('renders the correct default value', function () {
+      const inputField = document.getElementById('semester') as HTMLInputElement;
+      const defaultValue = inputField.value;
+      strictEqual(defaultValue, 'Spring');
+    });
+    it('does not render the error message', function () {
+      const errorField = queryByText('error');
+      strictEqual(errorField, null);
+    });
+
+    it('gap and margin and grid-template-rows style', function () {
+      const style = window.getComputedStyle(getByText('semester').parentNode as HTMLElement);
+      strictEqual(style['grid-template-rows'], '1fr');
+      strictEqual(style.gap, '0px');
+      strictEqual(style.margin, '0px');
+    });
+  });
   context('when errorMessage prop is not present', function () {
     beforeEach(function () {
       changeSpy = spy();

--- a/src/Forms/__tests__/TextInput.test.tsx
+++ b/src/Forms/__tests__/TextInput.test.tsx
@@ -152,6 +152,48 @@ describe('Text input', function () {
       strictEqual(style['grid-template-rows'], '1fr');
     });
   });
+  context('when hideError is set and isLabelVisible is not ', function () {
+    beforeEach(function () {
+      changeSpy = spy();
+      ({ queryByText, getByText } = render(
+        <TextInput
+          id="semester"
+          name="semester"
+          value="Spring"
+          label="semester"
+          hideError
+          isLabelVisible={false}
+          onChange={changeSpy}
+        />
+      ));
+    });
+    it('renders', function () {
+      const inputElement = document.getElementById('semester') as HTMLInputElement;
+      strictEqual(!!inputElement, true);
+    });
+    it('calls the change handler when changed', function () {
+      fireEvent.change(document.getElementById('semester'), {
+        target: {
+          value: 'Fall',
+        },
+      });
+      strictEqual(changeSpy.callCount, 1);
+    });
+    it('renders the correct default value', function () {
+      const inputField = document.getElementById('semester') as HTMLInputElement;
+      const defaultValue = inputField.value;
+      strictEqual(defaultValue, 'Spring');
+    });
+    it('does not render the error message', function () {
+      const errorField = queryByText('error');
+      strictEqual(errorField, null);
+    });
+    it('set grid-template-rows styles accordingly', function () {
+      const style = window.getComputedStyle(getByText('semester').parentNode as HTMLElement);
+      strictEqual(style['grid-template-rows'], '1fr');
+      strictEqual(style.gap, '0px');
+    });
+  });
   context('when hideError prop is not set', function () {
     beforeEach(function () {
       changeSpy = spy();

--- a/src/Forms/__tests__/TextInput.test.tsx
+++ b/src/Forms/__tests__/TextInput.test.tsx
@@ -72,50 +72,6 @@ describe('Text input', function () {
       strictEqual(error.id, `${inputId}-error`);
     });
   });
-  context('when hideError prop is set to true', function () {
-    beforeEach(function () {
-      changeSpy = spy();
-      ({ queryByText, getByText } = render(
-        <TextInput
-          id="semester"
-          name="semester"
-          value="Spring"
-          label="semester"
-          errorMessage="Error: Please enter a valid ID"
-          hideError
-          onChange={changeSpy}
-        />
-      ));
-    });
-    it('renders', function () {
-      const inputElement = document.getElementById('semester') as HTMLInputElement;
-      strictEqual(!!inputElement, true);
-    });
-    it('calls the change handler when changed', function () {
-      fireEvent.change(document.getElementById('semester'), {
-        target: {
-          value: 'Fall',
-        },
-      });
-      strictEqual(changeSpy.callCount, 1);
-    });
-    it('renders the correct default value', function () {
-      const inputField = document.getElementById('semester') as HTMLInputElement;
-      const defaultValue = inputField.value;
-      strictEqual(defaultValue, 'Spring');
-    });
-    it('does not render the error message', function () {
-      const errorField = queryByText('error');
-      strictEqual(errorField, null);
-    });
-
-    it('gap and margin and grid-template-rows style', function () {
-      const style = window.getComputedStyle(getByText('semester').parentNode as HTMLElement);
-      strictEqual(style['grid-template-rows'], '1fr');
-      strictEqual(style.gap, '0px');
-      strictEqual(style.margin, '0px');
-    });
-  });
   context('when errorMessage prop is not present', function () {
     beforeEach(function () {
       changeSpy = spy();
@@ -153,6 +109,84 @@ describe('Text input', function () {
     it('does not set aria-invalid', function () {
       const input = getByRole('textbox');
       strictEqual(input.hasAttribute('aria-invalid'), false);
+    });
+  });
+  context('when hideError and errorMessage prop are present', function () {
+    beforeEach(function () {
+      changeSpy = spy();
+      ({ queryByText, getByText } = render(
+        <TextInput
+          id="semester"
+          name="semester"
+          value="Spring"
+          label="semester"
+          errorMessage="Error: Please enter a valid ID"
+          hideError
+          onChange={changeSpy}
+        />
+      ));
+    });
+    it('renders', function () {
+      const inputElement = document.getElementById('semester') as HTMLInputElement;
+      strictEqual(!!inputElement, true);
+    });
+    it('calls the change handler when changed', function () {
+      fireEvent.change(document.getElementById('semester'), {
+        target: {
+          value: 'Fall',
+        },
+      });
+      strictEqual(changeSpy.callCount, 1);
+    });
+    it('renders the correct default value', function () {
+      const inputField = document.getElementById('semester') as HTMLInputElement;
+      const defaultValue = inputField.value;
+      strictEqual(defaultValue, 'Spring');
+    });
+    it('does not render the error message', function () {
+      const errorField = queryByText('error');
+      strictEqual(errorField, null);
+    });
+    it('gap and margin and grid-template-rows style', function () {
+      const style = window.getComputedStyle(getByText('semester').parentNode as HTMLElement);
+      strictEqual(style['grid-template-rows'], '1fr');
+      strictEqual(style.gap, '0px');
+      strictEqual(style.margin, '0px');
+    });
+  });
+  context('when hideError prop is not set', function () {
+    beforeEach(function () {
+      changeSpy = spy();
+      ({ getByText } = render(
+        <TextInput
+          id="semester"
+          name="semester"
+          value="Spring"
+          label="semester"
+          onChange={changeSpy}
+        />
+      ));
+    });
+    it('renders', function () {
+      const inputElement = document.getElementById('semester') as HTMLInputElement;
+      strictEqual(!!inputElement, true);
+    });
+    it('calls the change handler when changed', function () {
+      fireEvent.change(document.getElementById('semester'), {
+        target: {
+          value: 'Fall',
+        },
+      });
+      strictEqual(changeSpy.callCount, 1);
+    });
+    it('renders the correct default value', function () {
+      const inputField = document.getElementById('semester') as HTMLInputElement;
+      const defaultValue = inputField.value;
+      strictEqual(defaultValue, 'Spring');
+    });
+    it('gap and margin and grid-template-rows style', function () {
+      const style = window.getComputedStyle(getByText('semester').parentNode as HTMLElement);
+      strictEqual(style['grid-template-rows'], '1fr minmax(1em,max-content)');
     });
   });
   context('when isRequired prop is present', function () {

--- a/src/Forms/__tests__/TextInput.test.tsx
+++ b/src/Forms/__tests__/TextInput.test.tsx
@@ -147,11 +147,9 @@ describe('Text input', function () {
       const errorField = queryByText('error');
       strictEqual(errorField, null);
     });
-    it('gap and margin and grid-template-rows style', function () {
+    it('set grid-template-rows styles accordingly', function () {
       const style = window.getComputedStyle(getByText('semester').parentNode as HTMLElement);
       strictEqual(style['grid-template-rows'], '1fr');
-      strictEqual(style.gap, '0px');
-      strictEqual(style.margin, '0px');
     });
   });
   context('when hideError prop is not set', function () {
@@ -184,7 +182,7 @@ describe('Text input', function () {
       const defaultValue = inputField.value;
       strictEqual(defaultValue, 'Spring');
     });
-    it('gap and margin and grid-template-rows style', function () {
+    it('set grid-template-rows styles accordingly', function () {
       const style = window.getComputedStyle(getByText('semester').parentNode as HTMLElement);
       strictEqual(style['grid-template-rows'], '1fr minmax(1em,max-content)');
     });


### PR DESCRIPTION
New Feature: 
Adding a hideError Prop to the the TextInput.

hideError will be used by the TextInput to hide the error if exist.
It will be used by the label to adjust the style of the area of the errorMessage(will remove the spaces under the TextInput).

Tests of the hideError is included in the InputText test. 
