### PR TITLE
Add Mark One Props Interface

### DIFF
--- a/examples/Buttons/BorderlessButton.md
+++ b/examples/Buttons/BorderlessButton.md
@@ -86,7 +86,10 @@ import { faTrash } from '@fortawesome/free-solid-svg-icons';
 ### With the `forwardRef`
 Ref example: The optional `forwardRef` property is set. When the primary themed button is clicked, the focus shifts to the borderless button.
 ```jsx
-import { useState, useRef, } from 'react';
+import {
+  useState,
+  useRef,
+} from 'react';
 import {
   Button,
   VARIANT,

--- a/examples/Buttons/BorderlessButton.md
+++ b/examples/Buttons/BorderlessButton.md
@@ -118,6 +118,7 @@ const BorderlessButtonRefExample = () => {
       variant={VARIANT.DANGER}
       tabIndex={0}
       forwardRef={ref}
+      alt="testing"
     >
       <FontAwesomeIcon icon={faTrash} size="lg" />
     </BorderlessButton>

--- a/examples/Buttons/BorderlessButton.md
+++ b/examples/Buttons/BorderlessButton.md
@@ -118,7 +118,7 @@ const BorderlessButtonRefExample = () => {
       variant={VARIANT.DANGER}
       tabIndex={0}
       forwardRef={ref}
-      alt="testing"
+      alt="testing delete"
     >
       <FontAwesomeIcon icon={faTrash} size="lg" />
     </BorderlessButton>

--- a/examples/Buttons/BorderlessButton.md
+++ b/examples/Buttons/BorderlessButton.md
@@ -101,7 +101,7 @@ const BorderlessButtonRefExample = () => {
   const ref = useRef(null);
   const [value, setValue] = useState('');
   const onButtonClick = () => {
-    setTimeout(() => ref.current.focus());
+    ref.current.focus();
   }
   return (
     <>

--- a/examples/Buttons/BorderlessButton.md
+++ b/examples/Buttons/BorderlessButton.md
@@ -11,7 +11,7 @@ import { faArrowUp } from '@fortawesome/free-solid-svg-icons';
   }}
   variant={VARIANT.BASE}
 >
-  <FontAwesomeIcon icon={faArrowUp} size="small" />
+  <FontAwesomeIcon icon={faArrowUp} size="lg" />
 </BorderlessButton>
 ```
 
@@ -28,7 +28,7 @@ import { faEnvelope } from '@fortawesome/free-solid-svg-icons';
   }}
   variant={VARIANT.PRIMARY}
 >
-  <FontAwesomeIcon icon={faEnvelope} size="small" />
+  <FontAwesomeIcon icon={faEnvelope} size="lg" />
 </BorderlessButton>
 ```
 
@@ -45,7 +45,7 @@ import { faTimes } from '@fortawesome/free-solid-svg-icons';
   }}
   variant={VARIANT.SECONDARY}
 >
-  <FontAwesomeIcon icon={faTimes} size="small" />
+  <FontAwesomeIcon icon={faTimes} size="lg" />
 </BorderlessButton>
 ```
 
@@ -62,7 +62,7 @@ import { faQuestion } from '@fortawesome/free-solid-svg-icons';
   }}
   variant={VARIANT.INFO}
 >
-  <FontAwesomeIcon icon={faQuestion} size="small" />
+  <FontAwesomeIcon icon={faQuestion} size="lg" />
 </BorderlessButton>
 ```
 
@@ -79,6 +79,47 @@ import { faTrash } from '@fortawesome/free-solid-svg-icons';
   }}
   variant={VARIANT.DANGER}
 >
-  <FontAwesomeIcon icon={faTrash} size="small" />
+  <FontAwesomeIcon icon={faTrash} size="lg" />
 </BorderlessButton>
+```
+
+### With the `forwardRef`
+Ref example: The optional `forwardRef` property is set. When the primary themed button is clicked, the focus shifts to the borderless button.
+```jsx
+import { useState, useRef, } from 'react';
+import {
+  Button,
+  VARIANT,
+  } from 'mark-one';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faTrash } from '@fortawesome/free-solid-svg-icons';
+
+const BorderlessButtonRefExample = () => {
+  const ref = useRef(null);
+  const [value, setValue] = useState('');
+  const onButtonClick = () => {
+    setTimeout(() => ref.current.focus());
+  }
+  return (
+    <>
+    <Button
+      onClick={onButtonClick}
+      variant={VARIANT.PRIMARY}
+    >
+      Focus the Borderless Button
+    </Button>
+    <BorderlessButton
+      onClick={function() {
+        alert('You clicked the borderless button in which variant equals VARIANT.DANGER')
+      }}
+      variant={VARIANT.DANGER}
+      tabIndex={0}
+      forwardRef={ref}
+    >
+      <FontAwesomeIcon icon={faTrash} size="lg" />
+    </BorderlessButton>
+    </>
+  );
+};
+<BorderlessButtonRefExample />
 ```

--- a/examples/Buttons/BorderlessButton.md
+++ b/examples/Buttons/BorderlessButton.md
@@ -116,7 +116,6 @@ const BorderlessButtonRefExample = () => {
         alert('You clicked the borderless button in which variant equals VARIANT.DANGER')
       }}
       variant={VARIANT.DANGER}
-      tabIndex={0}
       forwardRef={ref}
       alt="testing delete"
     >

--- a/examples/Buttons/Button.md
+++ b/examples/Buttons/Button.md
@@ -71,3 +71,46 @@ import { VARIANT } from 'mark-one';
   Click Me!
 </Button>
 ```
+
+### With the `forwardRef`
+Ref example: The optional `forwardRef` property is set. When the primary themed button is clicked, the focus shifts to the borderless button.
+```jsx
+import {
+  useState,
+  useRef,
+} from 'react';
+import { VARIANT } from 'mark-one';
+
+const ButtonRefExample = () => {
+  const ref = useRef(null);
+  const [value, setValue] = useState('');
+  const onButtonClick = () => {
+    setTimeout(() => ref.current.focus());
+  }
+  return (
+    <>
+    <div>
+    <Button
+      onClick={onButtonClick}
+      variant={VARIANT.PRIMARY}
+    >
+      Focus the Danger Button
+    </Button>
+    </div>
+    <div>
+    <Button
+      onClick={function() {
+        alert('You clicked the button in which variant equals VARIANT.DANGER')
+      }}
+      variant={VARIANT.DANGER}
+      tabIndex={0}
+      forwardRef={ref}
+    >
+      Danger Button
+    </Button>
+    </div>
+    </>
+  );
+};
+<ButtonRefExample />
+```

--- a/examples/Buttons/Button.md
+++ b/examples/Buttons/Button.md
@@ -83,7 +83,6 @@ import { VARIANT } from 'mark-one';
 
 const ButtonRefExample = () => {
   const ref = useRef(null);
-  const [value, setValue] = useState('');
   const onButtonClick = () => {
     setTimeout(() => ref.current.focus());
   }

--- a/examples/Buttons/Button.md
+++ b/examples/Buttons/Button.md
@@ -93,7 +93,7 @@ const ButtonRefExample = () => {
       onClick={onButtonClick}
       variant={VARIANT.PRIMARY}
     >
-      Focus the Danger Button
+      Focus the Other Button
     </Button>
     </div>
     <div>
@@ -102,10 +102,9 @@ const ButtonRefExample = () => {
         alert('You clicked the button in which variant equals VARIANT.DANGER')
       }}
       variant={VARIANT.DANGER}
-      tabIndex={0}
       forwardRef={ref}
     >
-      Danger Button
+      Other Button
     </Button>
     </div>
     </>

--- a/examples/Buttons/Button.md
+++ b/examples/Buttons/Button.md
@@ -84,7 +84,7 @@ import { VARIANT } from 'mark-one';
 const ButtonRefExample = () => {
   const ref = useRef(null);
   const onButtonClick = () => {
-    setTimeout(() => ref.current.focus());
+    ref.current.focus();
   }
   return (
     <>

--- a/src/Buttons/BorderlessButton.tsx
+++ b/src/Buttons/BorderlessButton.tsx
@@ -46,7 +46,6 @@ ReactElement => {
     disabled,
     variant,
     forwardRef,
-    tabIndex,
     alt,
   } = props;
   const theme = useContext(ThemeContext);
@@ -58,7 +57,6 @@ ReactElement => {
       disabled={disabled}
       variant={variant}
       ref={forwardRef}
-      tabIndex={tabIndex}
       aria-label={alt}
     >
       { children }

--- a/src/Buttons/BorderlessButton.tsx
+++ b/src/Buttons/BorderlessButton.tsx
@@ -3,10 +3,10 @@ import React, {
 } from 'react';
 import styled, { ThemeContext } from 'styled-components';
 import { FontAwesomeIconProps } from '@fortawesome/react-fontawesome';
-import { MarkOneInterface } from 'Theme/MarkOneWrapper';
+import { MarkOneProps } from 'Theme/MarkOneWrapper';
 import { VARIANT, fromTheme } from '../Theme';
 
-export interface BorderlessButtonProps extends MarkOneInterface {
+export interface BorderlessButtonProps extends MarkOneProps {
   /** The id of the button */
   id?: string;
   /** Specifies the Font Awesome Icon(s) */

--- a/src/Buttons/BorderlessButton.tsx
+++ b/src/Buttons/BorderlessButton.tsx
@@ -3,9 +3,10 @@ import React, {
 } from 'react';
 import styled, { ThemeContext } from 'styled-components';
 import { FontAwesomeIconProps } from '@fortawesome/react-fontawesome';
+import { MarkOneInterface } from 'Theme/MarkOneWrapper';
 import { VARIANT, fromTheme } from '../Theme';
 
-export interface BorderlessButtonProps {
+export interface BorderlessButtonProps extends MarkOneInterface {
   /** The id of the button */
   id?: string;
   /** Specifies the Font Awesome Icon(s) */
@@ -44,6 +45,9 @@ ReactElement => {
     children,
     disabled,
     variant,
+    forwardRef,
+    tabIndex,
+    alt,
   } = props;
   const theme = useContext(ThemeContext);
   return (
@@ -53,6 +57,9 @@ ReactElement => {
       theme={theme}
       disabled={disabled}
       variant={variant}
+      ref={forwardRef}
+      tabIndex={tabIndex}
+      aria-label={alt}
     >
       { children }
     </StyledBorderlessButton>

--- a/src/Buttons/BorderlessButton.tsx
+++ b/src/Buttons/BorderlessButton.tsx
@@ -6,7 +6,7 @@ import { FontAwesomeIconProps } from '@fortawesome/react-fontawesome';
 import { MarkOneProps } from 'Theme/MarkOneWrapper';
 import { VARIANT, fromTheme } from '../Theme';
 
-export interface BorderlessButtonProps extends MarkOneProps {
+export interface BorderlessButtonProps extends MarkOneProps<HTMLButtonElement> {
   /** The id of the button */
   id?: string;
   /** Specifies the Font Awesome Icon(s) */

--- a/src/Buttons/Button.tsx
+++ b/src/Buttons/Button.tsx
@@ -53,7 +53,6 @@ const Button: FunctionComponent<ButtonProps> = (props): ReactElement => {
     disabled,
     variant,
     forwardRef,
-    tabIndex,
     alt,
   } = props;
   const theme = useContext(ThemeContext);
@@ -65,7 +64,6 @@ const Button: FunctionComponent<ButtonProps> = (props): ReactElement => {
       disabled={disabled}
       variant={variant}
       ref={forwardRef}
-      tabIndex={tabIndex}
       aria-label={alt}
     >
       { children }

--- a/src/Buttons/Button.tsx
+++ b/src/Buttons/Button.tsx
@@ -9,7 +9,7 @@ import styled, { ThemeContext } from 'styled-components';
 import { MarkOneProps } from 'Theme/MarkOneWrapper';
 import { VARIANT, fromTheme } from '../Theme';
 
-export interface ButtonProps extends MarkOneProps {
+export interface ButtonProps extends MarkOneProps<HTMLButtonElement> {
   /** The id of the button */
   id?: string;
   /** Text or components to be displayed on the button */

--- a/src/Buttons/Button.tsx
+++ b/src/Buttons/Button.tsx
@@ -6,10 +6,10 @@ import React, {
   MouseEventHandler,
 } from 'react';
 import styled, { ThemeContext } from 'styled-components';
-import { MarkOneInterface } from 'Theme/MarkOneWrapper';
+import { MarkOneProps } from 'Theme/MarkOneWrapper';
 import { VARIANT, fromTheme } from '../Theme';
 
-export interface ButtonProps extends MarkOneInterface {
+export interface ButtonProps extends MarkOneProps {
   /** The id of the button */
   id?: string;
   /** Text or components to be displayed on the button */

--- a/src/Buttons/Button.tsx
+++ b/src/Buttons/Button.tsx
@@ -6,9 +6,10 @@ import React, {
   MouseEventHandler,
 } from 'react';
 import styled, { ThemeContext } from 'styled-components';
+import { MarkOneInterface } from 'Theme/MarkOneWrapper';
 import { VARIANT, fromTheme } from '../Theme';
 
-export interface ButtonProps {
+export interface ButtonProps extends MarkOneInterface {
   /** The id of the button */
   id?: string;
   /** Text or components to be displayed on the button */
@@ -51,6 +52,9 @@ const Button: FunctionComponent<ButtonProps> = (props): ReactElement => {
     onClick,
     disabled,
     variant,
+    forwardRef,
+    tabIndex,
+    alt,
   } = props;
   const theme = useContext(ThemeContext);
   return (
@@ -60,6 +64,9 @@ const Button: FunctionComponent<ButtonProps> = (props): ReactElement => {
       theme={theme}
       disabled={disabled}
       variant={variant}
+      ref={forwardRef}
+      tabIndex={tabIndex}
+      aria-label={alt}
     >
       { children }
     </StyledButton>

--- a/src/Buttons/__tests__/BorderlessButton.test.tsx
+++ b/src/Buttons/__tests__/BorderlessButton.test.tsx
@@ -76,11 +76,7 @@ describe('Borderless Button', function () {
       const ButtonRefExample = () => {
         const ref = useRef<HTMLInputElement>(null);
         const onButtonClick = () => {
-          setTimeout(() => {
-            if (ref.current) {
-              ref.current.focus();
-            }
-          });
+          ref.current.focus();
         };
         return (
           <>

--- a/src/Buttons/__tests__/BorderlessButton.test.tsx
+++ b/src/Buttons/__tests__/BorderlessButton.test.tsx
@@ -1,21 +1,27 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import {
   render,
   fireEvent,
   BoundFunction,
   GetByBoundAttribute,
+  GetByText,
+  GetByRole,
+  wait,
 } from 'test-utils';
 import {
   spy,
   SinonSpy,
 } from 'sinon';
-import assert from 'assert';
+import assert, { strictEqual } from 'assert';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faArrowUp } from '@fortawesome/free-solid-svg-icons';
+import { faArrowUp, faTrash } from '@fortawesome/free-solid-svg-icons';
+import { Button } from 'Buttons';
 import { VARIANT } from '../../Theme';
 import BorderlessButton from '../BorderlessButton';
 
 describe('Borderless Button', function () {
+  let getByText: BoundFunction<GetByText>;
+  let getByRole: BoundFunction<GetByRole>;
   let getByTestId: BoundFunction<GetByBoundAttribute>;
   let clickSpy: SinonSpy;
   context('when disabled prop is false', function () {
@@ -63,6 +69,49 @@ describe('Borderless Button', function () {
     it('does not call the click handler when clicked', function () {
       fireEvent.click(getByTestId('test-button'));
       assert.strictEqual(clickSpy.callCount, 0);
+    });
+  });
+  context('when forwardRef prop is present', function () {
+    beforeEach(function () {
+      const ButtonRefExample = () => {
+        const ref = useRef<HTMLInputElement>(null);
+        const onButtonClick = () => {
+          setTimeout(() => {
+            if (ref.current) {
+              ref.current.focus();
+            }
+          });
+        };
+        return (
+          <>
+            <Button
+              onClick={onButtonClick}
+              variant={VARIANT.PRIMARY}
+            >
+              Focus the Borderless Button
+            </Button>
+            <BorderlessButton
+              onClick={() => {}}
+              variant={VARIANT.DANGER}
+              tabIndex={0}
+              forwardRef={ref}
+              alt="Danger Button"
+            >
+              <FontAwesomeIcon icon={faTrash} size="lg" />
+            </BorderlessButton>
+          </>
+        );
+      };
+      ({ getByText, getByRole } = render(
+        <ButtonRefExample />
+      ));
+    });
+    it('can be used to shift the focus to the button', async function () {
+      const initialButton = getByText('Focus the Borderless Button');
+      initialButton.click();
+      const borderlessButton = getByRole('button', { name: 'Danger Button' });
+      await wait(() => document.activeElement === borderlessButton);
+      strictEqual(document.activeElement, borderlessButton);
     });
   });
 });

--- a/src/Buttons/__tests__/BorderlessButton.test.tsx
+++ b/src/Buttons/__tests__/BorderlessButton.test.tsx
@@ -95,7 +95,7 @@ describe('Borderless Button', function () {
               variant={VARIANT.DANGER}
               tabIndex={0}
               forwardRef={ref}
-              alt="Danger Button"
+              alt="Borderless Button"
             >
               <FontAwesomeIcon icon={faTrash} size="lg" />
             </BorderlessButton>
@@ -109,7 +109,7 @@ describe('Borderless Button', function () {
     it('can be used to shift the focus to the button', async function () {
       const initialButton = getByText('Focus the Borderless Button');
       initialButton.click();
-      const borderlessButton = getByRole('button', { name: 'Danger Button' });
+      const borderlessButton = getByRole('button', { name: 'Borderless Button' });
       await wait(() => document.activeElement === borderlessButton);
       strictEqual(document.activeElement, borderlessButton);
     });

--- a/src/Buttons/__tests__/BorderlessButton.test.tsx
+++ b/src/Buttons/__tests__/BorderlessButton.test.tsx
@@ -93,7 +93,6 @@ describe('Borderless Button', function () {
             <BorderlessButton
               onClick={() => {}}
               variant={VARIANT.DANGER}
-              tabIndex={0}
               forwardRef={ref}
               alt="Borderless Button"
             >

--- a/src/Buttons/__tests__/Button.test.tsx
+++ b/src/Buttons/__tests__/Button.test.tsx
@@ -88,7 +88,6 @@ describe('Button', function () {
             <Button
               onClick={(): void => {}}
               variant={VARIANT.DANGER}
-              tabIndex={0}
               forwardRef={ref}
             >
               Basic Button

--- a/src/Buttons/__tests__/Button.test.tsx
+++ b/src/Buttons/__tests__/Button.test.tsx
@@ -91,7 +91,7 @@ describe('Button', function () {
               tabIndex={0}
               forwardRef={ref}
             >
-              Danger Button
+              Basic Button
             </Button>
           </>
         );
@@ -103,9 +103,9 @@ describe('Button', function () {
     it('can be used to shift the focus to the button', async function () {
       const initialButton = getByText('Focus the Other Button');
       initialButton.click();
-      const dangerButton = getByText('Danger Button');
-      await wait(() => document.activeElement === dangerButton);
-      strictEqual(document.activeElement as HTMLElement, dangerButton);
+      const basicButton = getByText('Basic Button');
+      await wait(() => document.activeElement === basicButton);
+      strictEqual(document.activeElement as HTMLElement, basicButton);
     });
   });
 });

--- a/src/Buttons/__tests__/Button.test.tsx
+++ b/src/Buttons/__tests__/Button.test.tsx
@@ -71,11 +71,7 @@ describe('Button', function () {
       const ButtonRefExample = () => {
         const ref = useRef<HTMLInputElement>(null);
         const onButtonClick = () => {
-          setTimeout(() => {
-            if (ref.current) {
-              ref.current.focus();
-            }
-          });
+          ref.current.focus();
         };
         return (
           <>

--- a/src/Buttons/__tests__/Button.test.tsx
+++ b/src/Buttons/__tests__/Button.test.tsx
@@ -1,15 +1,18 @@
-import React from 'react';
+import React, { useRef } from 'react';
+import assert, {
+  strictEqual,
+} from 'assert';
 import {
   render,
   fireEvent,
   BoundFunction,
   GetByText,
+  wait,
 } from 'test-utils';
 import {
   spy,
   SinonSpy,
 } from 'sinon';
-import assert from 'assert';
 import { VARIANT } from '../../Theme';
 import Button from '../Button';
 
@@ -61,6 +64,48 @@ describe('Button', function () {
     it('does not call the click handler when clicked', function () {
       fireEvent.click(getByText('Not Clickable'));
       assert.strictEqual(clickSpy.callCount, 0);
+    });
+  });
+  context('when forwardRef prop is present', function () {
+    beforeEach(function () {
+      const ButtonRefExample = () => {
+        const ref = useRef<HTMLInputElement>(null);
+        const onButtonClick = () => {
+          setTimeout(() => {
+            if (ref.current) {
+              ref.current.focus();
+            }
+          });
+        };
+        return (
+          <>
+            <Button
+              onClick={onButtonClick}
+              variant={VARIANT.PRIMARY}
+            >
+              Focus the Other Button
+            </Button>
+            <Button
+              onClick={(): void => {}}
+              variant={VARIANT.DANGER}
+              tabIndex={0}
+              forwardRef={ref}
+            >
+              Danger Button
+            </Button>
+          </>
+        );
+      };
+      ({ getByText } = render(
+        <ButtonRefExample />
+      ));
+    });
+    it('can be used to shift the focus to the button', async function () {
+      const initialButton = getByText('Focus the Other Button');
+      initialButton.click();
+      const dangerButton = getByText('Danger Button');
+      await wait(() => document.activeElement === dangerButton);
+      strictEqual(document.activeElement as HTMLElement, dangerButton);
     });
   });
 });

--- a/src/Theme/MarkOneWrapper.tsx
+++ b/src/Theme/MarkOneWrapper.tsx
@@ -12,7 +12,7 @@ import MarkOneTheme from './MarkOneTheme';
  * This interface includes props that are common to many components for testing
  * and accessibility purposes.
  */
-export interface MarkOneInterface {
+export interface MarkOneProps {
   /** Specifies the ref of the element */
   forwardRef?: Ref<HTMLElement>;
   /** Corresponds to HTML attribute tabindex */

--- a/src/Theme/MarkOneWrapper.tsx
+++ b/src/Theme/MarkOneWrapper.tsx
@@ -12,9 +12,9 @@ import MarkOneTheme from './MarkOneTheme';
  * This interface includes props that are common to many components for testing
  * and accessibility purposes.
  */
-export interface MarkOneProps {
+export interface MarkOneProps<T extends HTMLElement> {
   /** Specifies the ref of the element */
-  forwardRef?: Ref<HTMLElement>;
+  forwardRef?: Ref<T>;
   /** Corresponds to HTML attribute tabindex */
   tabIndex?: number;
   /** Specifies the alt text for screen readers */

--- a/src/Theme/MarkOneWrapper.tsx
+++ b/src/Theme/MarkOneWrapper.tsx
@@ -1,9 +1,25 @@
 import React, {
-  ReactElement, ReactNode, FunctionComponent,
+  ReactElement,
+  ReactNode,
+  FunctionComponent,
+  Ref,
 } from 'react';
 import { ThemeProvider } from 'styled-components';
 import GlobalCSS from './GlobalCSS';
 import MarkOneTheme from './MarkOneTheme';
+
+/**
+ * This interface includes props that are common to many components for testing
+ * and accessibility purposes.
+ */
+export interface MarkOneInterface {
+  /** Specifies the ref of the element */
+  forwardRef?: Ref<HTMLElement>;
+  /** Corresponds to HTML attribute tabindex */
+  tabIndex?: number;
+  /** Specifies the alt text for screen readers */
+  alt?: string;
+}
 
 export interface ThemeWrapperProps {
   /** The content of the app that should receive the theme */


### PR DESCRIPTION
This interface was added as a result of feedback from the course planner [absence modal PR ](https://github.com/seas-computing/course-planner/pull/276). In that ticket, I was using `document.getElementById` to get a reference to button elements to focus them. Jonathan Seitz recommended that we should be using `ref` instead. We had a discussion on this and concluded that since the properties `ref` and `aria-label` will eventually be used across many different `mark one` components, it would make sense to make an interface for these components at the top level of `mark one` so that component props could extend the interface to include these common props. We decided it made sense to only implement the interface for the components needed in the absence modal for now, which would be the button components. 

## Types of changes
<!--
  What types of changes does your code introduce? Put an `x` in all the boxes
  that apply:
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
<!--
  Go over all the following points, and put an `x` in all the boxes that apply.
-->
- [x] I have run `eslint` on the code
- [x] I have added JSDoc for all of my code (where applicable)
- [x] I have added tests to cover my changes.

## Priority:
- [x] Normal <!-- New piece of functionality -->
- [ ] High <!-- Critical bug requiring urgent review -->

## Related Issues:
<!--
  Add the issue number in below that this PR is intended to address.

  Also mention any issues that this PR is related to, and if possible,
  provide more information regarding the relationship to the issues in
  question (i.e does the PR fix the issue, is it designed to fix another bug
  that is similar to the issue etc.)
-->
Addresses [#252](https://github.com/seas-computing/course-planner/issues/252)

<!--
  Attribution:
  PR Template adapted from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->