### PR TITLE
Feature/224 add accessibility to the label

### DIFF
--- a/examples/Forms/Dropdown.md
+++ b/examples/Forms/Dropdown.md
@@ -124,8 +124,8 @@ const [value, setValue] = useState('fall');
     },
   ]}
   value={value}
-  id="semesters"
-  name="semesters"
+  id="isLabelVisibleDropExample"
+  name="isLabelVisibleDropExample"
   onChange={function(event){
     setValue(event.target.value);
     alert('You changed the selection to ' + event.target.value);
@@ -303,8 +303,8 @@ const [value, setValue] = useState('fall');
     },
   ]}
   value={value}
-  id="semesters"
-  name="semesters"
+  id="hideErrorDropExample"
+  name="hideErrorDropExample"
   onChange={function(event){
     setValue(event.target.value);
     alert('You changed the selection to ' + event.target.value);

--- a/examples/Forms/TextInput.md
+++ b/examples/Forms/TextInput.md
@@ -65,8 +65,8 @@ const [value, setValue] = useState('Some valid input');
 
 <TextInput
   value={value}
-  name="example"
-  id="example"
+  name="isLabelVisibleTextExample"
+  id="isLabelVisibleTextExample"
   label="Description:"
   isLabelVisible={false}
   onChange={(event) => {
@@ -183,8 +183,8 @@ const [value, setValue] = useState('Some valid input');
 
 <TextInput
   value={value}
-  name="example"
-  id="example"
+  name="hideErrorTextExample"
+  id="hideErrorTextExample"
   label="Description:"
   errorMessage="Error: Please enter a valid ID"
   hideError={true}

--- a/src/Forms/InputLabel.tsx
+++ b/src/Forms/InputLabel.tsx
@@ -65,7 +65,7 @@ const accessibility = `
   margin: -1px;
   padding: 0;
   border: 0;
-`
+`;
 
 const generateGrid = (
   labelPosition: InputLabelPosition,
@@ -104,11 +104,7 @@ const StyledInputLabel = styled.label<StyledInputLabelProps>`
 `;
 
 const StyledInputLabelText = styled.span<StyledInputLabelTextProps>`
-  ${({ isLabelVisible }) => (
-    isLabelVisible
-    ? 'display: inline;'
-    : accessibility 
-  )};
+  ${({ isLabelVisible }) => (isLabelVisible ? 'display: inline;' : accessibility)};
   grid-area: l;
   justify-self: ${({ labelPosition }) => (
     labelPosition === POSITION.TOP

--- a/src/Forms/InputLabel.tsx
+++ b/src/Forms/InputLabel.tsx
@@ -56,6 +56,17 @@ export interface InputLabelProps {
   hideError?: boolean;
 }
 
+const accessibility = `
+  position: absolute;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  width: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+`
+
 const generateGrid = (
   labelPosition: InputLabelPosition,
   isLabelVisible: boolean
@@ -93,7 +104,11 @@ const StyledInputLabel = styled.label<StyledInputLabelProps>`
 `;
 
 const StyledInputLabelText = styled.span<StyledInputLabelTextProps>`
-  display: ${({ isLabelVisible }) => (isLabelVisible ? 'inline' : 'none')};
+  ${({ isLabelVisible }) => (
+    isLabelVisible
+    ? 'display: inline;'
+    : accessibility 
+  )};
   grid-area: l;
   justify-self: ${({ labelPosition }) => (
     labelPosition === POSITION.TOP

--- a/src/Forms/InputLabel.tsx
+++ b/src/Forms/InputLabel.tsx
@@ -56,7 +56,7 @@ export interface InputLabelProps {
   hideError?: boolean;
 }
 
-const accessibility = `
+const hideFromDisplay = `
   position: absolute;
   overflow: hidden;
   clip: rect(0 0 0 0);
@@ -104,7 +104,7 @@ const StyledInputLabel = styled.label<StyledInputLabelProps>`
 `;
 
 const StyledInputLabelText = styled.span<StyledInputLabelTextProps>`
-  ${({ isLabelVisible }) => (isLabelVisible ? 'display: inline;' : accessibility)};
+  ${({ isLabelVisible }) => (isLabelVisible ? '' : hideFromDisplay)};
   grid-area: l;
   justify-self: ${({ labelPosition }) => (
     labelPosition === POSITION.TOP

--- a/src/Forms/__tests__/Dropdown.test.tsx
+++ b/src/Forms/__tests__/Dropdown.test.tsx
@@ -415,7 +415,7 @@ describe('Dropdown', function () {
     });
     it('the label value is hidden in the UI', function () {
       const style = window.getComputedStyle(getByText('semesters'));
-      strictEqual(style.display, 'none');
+      strictEqual(style.overflow, 'hidden');
     });
   });
   context('when disabled prop is true', function () {

--- a/src/Forms/__tests__/Dropdown.test.tsx
+++ b/src/Forms/__tests__/Dropdown.test.tsx
@@ -420,7 +420,7 @@ describe('Dropdown', function () {
       ));
       deepStrictEqual(optionsFound, optionsWithDefaults);
     });
-    it('the label value is hidden in the UI', function () {
+    it('The label is still accessible in the DOM', function () {
       getByLabelText('semesters');
     });
   });

--- a/src/Forms/__tests__/Dropdown.test.tsx
+++ b/src/Forms/__tests__/Dropdown.test.tsx
@@ -17,6 +17,7 @@ import Dropdown from '../Dropdown';
 
 describe('Dropdown', function () {
   let getByText: BoundFunction<GetByText>;
+  let getByLabelText: BoundFunction<GetByText>;
   let getByRole: BoundFunction<GetByRole>;
   let getAllByRole: BoundFunction<AllByRole>;
   let queryByText: BoundFunction<QueryByText>;
@@ -370,7 +371,12 @@ describe('Dropdown', function () {
   context('when isLabelVisible prop is false', function () {
     beforeEach(function () {
       changeSpy = spy();
-      ({ getByText, getAllByRole, queryByText } = render(
+      ({
+        getByText,
+        getAllByRole,
+        queryByText,
+        getByLabelText,
+      } = render(
         <Dropdown
           id="semesters"
           options={options}
@@ -414,8 +420,7 @@ describe('Dropdown', function () {
       deepStrictEqual(optionsFound, optionsWithDefaults);
     });
     it('the label value is hidden in the UI', function () {
-      const style = window.getComputedStyle(getByText('semesters'));
-      strictEqual(style.overflow, 'hidden');
+      getByLabelText('semesters');
     });
   });
   context('when disabled prop is true', function () {

--- a/src/Forms/__tests__/TextInput.test.tsx
+++ b/src/Forms/__tests__/TextInput.test.tsx
@@ -364,7 +364,7 @@ describe('Text input', function () {
       const { value } = document.getElementById('semester') as HTMLInputElement;
       strictEqual(value, 'Spring');
     });
-    it('the label value is hidden in the UI', function () {
+    it('The label is still accessible in the DOM', function () {
       getByLabelText('invisibleLabel');
     });
   });

--- a/src/Forms/__tests__/TextInput.test.tsx
+++ b/src/Forms/__tests__/TextInput.test.tsx
@@ -21,6 +21,7 @@ enum POSITION {
 
 describe('Text input', function () {
   let getByText: BoundFunction<GetByText>;
+  let getByLabelText: BoundFunction<GetByText>;
   let getByRole: BoundFunction<GetByRole>;
   let queryByText: BoundFunction<QueryByText>;
   let changeSpy: SinonSpy;
@@ -301,7 +302,7 @@ describe('Text input', function () {
   context('when isLabelVisible prop is true', function () {
     beforeEach(function () {
       changeSpy = spy();
-      ({ getByText } = render(
+      ({ getByText, getByLabelText } = render(
         <TextInput
           id="semester"
           name="semester"
@@ -335,7 +336,7 @@ describe('Text input', function () {
   context('when isLabelVisible prop is false', function () {
     beforeEach(function () {
       changeSpy = spy();
-      ({ getByText } = render(
+      ({ getByLabelText } = render(
         <TextInput
           id="semester"
           name="semester"
@@ -363,8 +364,7 @@ describe('Text input', function () {
       strictEqual(value, 'Spring');
     });
     it('the label value is hidden in the UI', function () {
-      const style = window.getComputedStyle(getByText('invisibleLabel'));
-      strictEqual(style.overflow, 'hidden');
+      getByLabelText('invisibleLabel');
     });
   });
   context('when disabled prop is true', function () {

--- a/src/Forms/__tests__/TextInput.test.tsx
+++ b/src/Forms/__tests__/TextInput.test.tsx
@@ -364,7 +364,7 @@ describe('Text input', function () {
     });
     it('the label value is hidden in the UI', function () {
       const style = window.getComputedStyle(getByText('invisibleLabel'));
-      strictEqual(style.display, 'none');
+      strictEqual(style.overflow, 'hidden');
     });
   });
   context('when disabled prop is true', function () {


### PR DESCRIPTION
This PR related to the course planner ticket https://github.com/seas-computing/course-planner/issues/224
Based on the conversion with Vittorio, the invisible label should be accessible by the screen reader. Therefore the `dispaly: none` in the Label component in mark-one should be replaced with this css found in this url https://accessibility.18f.gov/hidden-content/

**Types of changes**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
- [x] I have run eslint on the code
- [ ] I have added JSDoc for all of my code (where applicable)
- [x] I have added tests to cover my changes.
**Priority:**
- [x] Normal
- [ ] High
