### PR TITLE
Add "required" property for TextInput and Dropdown

### DIFF
--- a/src/Forms/Checkbox.tsx
+++ b/src/Forms/Checkbox.tsx
@@ -135,6 +135,7 @@ const Checkbox: FunctionComponent<CheckboxProps> = (props): ReactElement => {
           value={value}
           name={name}
           aria-required={isRequired}
+          required={isRequired}
           onChange={onChange}
           disabled={disabled}
           ref={forwardRef}

--- a/src/Forms/Dropdown.tsx
+++ b/src/Forms/Dropdown.tsx
@@ -98,6 +98,7 @@ const Dropdown: FunctionComponent<DropdownProps> = (props): ReactElement => {
         aria-errormessage={`${id}-error`}
         aria-invalid={errorMessage ? true : null}
         aria-required={isRequired}
+        required={isRequired}
         ref={forwardRef}
         disabled={disabled}
       >

--- a/src/Forms/RadioButton.tsx
+++ b/src/Forms/RadioButton.tsx
@@ -139,6 +139,7 @@ ReactElement => {
           name={name}
           onChange={onChange}
           aria-required={isRequired}
+          required={isRequired}
           ref={forwardRef}
           theme={theme}
           checked={checked}

--- a/src/Forms/TextInput.tsx
+++ b/src/Forms/TextInput.tsx
@@ -100,6 +100,7 @@ const TextInput: FunctionComponent<TextInputProps> = (props): ReactElement => {
         aria-errormessage={`${id}-error`}
         aria-invalid={errorMessage ? true : null}
         aria-required={isRequired}
+        required={isRequired}
         ref={forwardRef}
       />
       {errorMessage && !hideError


### PR DESCRIPTION
We decided to take advantage of the HTML `required` property to indicate required form fields in the course admin modal. This property had not been exposed previously. I assigned the value of `isRequired` to the `required` property of the `TextInput` and `Dropdown` components.

## Types of changes
<!--
  What types of changes does your code introduce? Put an `x` in all the boxes
  that apply:
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
<!--
  Go over all the following points, and put an `x` in all the boxes that apply.
-->
- [x] I have run `eslint` on the code
- [x] I have added JSDoc for all of my code (where applicable)
- [ ] I have added tests to cover my changes.

## Priority:
- [x] Normal <!-- New piece of functionality -->
- [ ] High <!-- Critical bug requiring urgent review -->

## Related Issues:
<!--
  Add the issue number in below that this PR is intended to address.

  Also mention any issues that this PR is related to, and if possible,
  provide more information regarding the relationship to the issues in
  question (i.e does the PR fix the issue, is it designed to fix another bug
  that is similar to the issue etc.)
-->
Addresses [#229](https://github.com/seas-computing/course-planner/issues/229)

<!--
  Attribution:
  PR Template adapted from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->