### PR TITLE
TableCell Text Styling

### DIFF
--- a/examples/Tables/Table.md
+++ b/examples/Tables/Table.md
@@ -44,7 +44,7 @@ import {
 </Table>
 ```
 
-The following is an example of the `Table` component with the `alignment` prop set to the enum value `ALIGN.CENTER.` This example also demonstrates the usage of the `variant` property, which is set to `VARIANT.NEGATIVE` for two table cells.
+The following is an example of the `Table` component with the `alignment` prop set to the enum value `ALIGN.CENTER.` This example also demonstrates the usage of the `variant` property, which is set to `VARIANT.NEGATIVE` for two table cells and `VARIANT.MEDIUM` for another two table cells.
 
 ```jsx
 import {
@@ -74,8 +74,18 @@ import {
     </TableRow>
     <TableRow>
       <TableCell alignment={ALIGN.CENTER}>2</TableCell>
-      <TableCell alignment={ALIGN.CENTER}>Jack</TableCell>
-      <TableCell alignment={ALIGN.CENTER}>Thompson</TableCell>
+      <TableCell
+        alignment={ALIGN.CENTER}
+        variant={VARIANT.MEDIUM}
+      >
+        Jack
+      </TableCell>
+      <TableCell
+        alignment={ALIGN.CENTER}
+        variant={VARIANT.MEDIUM}
+      >
+        Thompson
+      </TableCell>
     </TableRow>
     <TableRow isStriped={true}>
       <TableCell alignment={ALIGN.CENTER}>3</TableCell>

--- a/examples/Tables/Table.md
+++ b/examples/Tables/Table.md
@@ -44,7 +44,7 @@ import {
 </Table>
 ```
 
-The following is an example of the `Table` component with the `alignment` prop set to the enum value `ALIGN.CENTER.`
+The following is an example of the `Table` component with the `alignment` prop set to the enum value `ALIGN.CENTER.` This example also demonstrates the usage of the `variant` property, which is set to `VARIANT.NEGATIVE` for two table cells.
 
 ```jsx
 import {

--- a/examples/Tables/Table.md
+++ b/examples/Tables/Table.md
@@ -44,7 +44,7 @@ import {
 </Table>
 ```
 
-The following is an example of the `Table` component with the `alignment` prop set to the enum value `ALIGN.CENTER.` This example also demonstrates the usage of the `variant` property, which is set to `TEXTVARIANT.NEGATIVE` for two table cells and `TEXTVARIANT.MEDIUM` for another two table cells.
+The following is an example of the `Table` component with the `alignment` prop set to the enum value `ALIGN.CENTER.` This example also demonstrates the usage of the `variant` property, which is set to `TEXT_VARIANT.NEGATIVE` for two table cells and `TEXT_VARIANT.MEDIUM` for another two table cells.
 
 ```jsx
 import {
@@ -55,7 +55,7 @@ import {
   TableRow,
   TableHeadingCell,
   TableHead,
-  TEXTVARIANT,
+  TEXT_VARIANT,
 } from 'mark-one';
 
 <Table>
@@ -76,13 +76,13 @@ import {
       <TableCell alignment={ALIGN.CENTER}>2</TableCell>
       <TableCell
         alignment={ALIGN.CENTER}
-        variant={TEXTVARIANT.MEDIUM}
+        variant={TEXT_VARIANT.MEDIUM}
       >
         Jack
       </TableCell>
       <TableCell
         alignment={ALIGN.CENTER}
-        variant={TEXTVARIANT.MEDIUM}
+        variant={TEXT_VARIANT.MEDIUM}
       >
         Thompson
       </TableCell>
@@ -91,13 +91,13 @@ import {
       <TableCell alignment={ALIGN.CENTER}>3</TableCell>
       <TableCell
         alignment={ALIGN.CENTER}
-        variant={TEXTVARIANT.NEGATIVE}
+        variant={TEXT_VARIANT.NEGATIVE}
       >
         Lianne
       </TableCell>
       <TableCell
         alignment={ALIGN.CENTER}
-        variant={TEXTVARIANT.NEGATIVE}
+        variant={TEXT_VARIANT.NEGATIVE}
       >
         Michaels
       </TableCell>

--- a/examples/Tables/Table.md
+++ b/examples/Tables/Table.md
@@ -44,7 +44,7 @@ import {
 </Table>
 ```
 
-The following is an example of the `Table` component with the `alignment` prop set to the enum value `ALIGN.CENTER.` This example also demonstrates the usage of the `variant` property, which is set to `VARIANT.NEGATIVE` for two table cells and `VARIANT.MEDIUM` for another two table cells.
+The following is an example of the `Table` component with the `alignment` prop set to the enum value `ALIGN.CENTER.` This example also demonstrates the usage of the `variant` property, which is set to `TEXTVARIANT.NEGATIVE` for two table cells and `TEXTVARIANT.MEDIUM` for another two table cells.
 
 ```jsx
 import {
@@ -55,7 +55,7 @@ import {
   TableRow,
   TableHeadingCell,
   TableHead,
-  VARIANT,
+  TEXTVARIANT,
 } from 'mark-one';
 
 <Table>
@@ -76,13 +76,13 @@ import {
       <TableCell alignment={ALIGN.CENTER}>2</TableCell>
       <TableCell
         alignment={ALIGN.CENTER}
-        variant={VARIANT.MEDIUM}
+        variant={TEXTVARIANT.MEDIUM}
       >
         Jack
       </TableCell>
       <TableCell
         alignment={ALIGN.CENTER}
-        variant={VARIANT.MEDIUM}
+        variant={TEXTVARIANT.MEDIUM}
       >
         Thompson
       </TableCell>
@@ -91,13 +91,13 @@ import {
       <TableCell alignment={ALIGN.CENTER}>3</TableCell>
       <TableCell
         alignment={ALIGN.CENTER}
-        variant={VARIANT.NEGATIVE}
+        variant={TEXTVARIANT.NEGATIVE}
       >
         Lianne
       </TableCell>
       <TableCell
         alignment={ALIGN.CENTER}
-        variant={VARIANT.NEGATIVE}
+        variant={TEXTVARIANT.NEGATIVE}
       >
         Michaels
       </TableCell>

--- a/examples/Tables/Table.md
+++ b/examples/Tables/Table.md
@@ -54,7 +54,8 @@ import {
   TableBody,
   TableRow,
   TableHeadingCell,
-  TableHead, 
+  TableHead,
+  VARIANT,
 } from 'mark-one';
 
 <Table>
@@ -78,8 +79,18 @@ import {
     </TableRow>
     <TableRow isStriped={true}>
       <TableCell alignment={ALIGN.CENTER}>3</TableCell>
-      <TableCell alignment={ALIGN.CENTER}>Lianne</TableCell>
-      <TableCell alignment={ALIGN.CENTER}>Michaels</TableCell>
+      <TableCell
+        alignment={ALIGN.CENTER}
+        variant={VARIANT.NEGATIVE}
+      >
+        Lianne
+      </TableCell>
+      <TableCell
+        alignment={ALIGN.CENTER}
+        variant={VARIANT.NEGATIVE}
+      >
+        Michaels
+      </TableCell>
     </TableRow>
     <TableRow>
       <TableCell alignment={ALIGN.CENTER}>4</TableCell>

--- a/src/Forms/__tests__/RadioButton.test.tsx
+++ b/src/Forms/__tests__/RadioButton.test.tsx
@@ -15,6 +15,7 @@ import userEvent from '@testing-library/user-event';
 import { Button } from 'Buttons';
 import { VARIANT } from 'Theme';
 import { POSITION } from 'Forms/InputLabel';
+import MarkOneTheme from 'Theme/MarkOneTheme';
 
 describe('Radio Button', function () {
   let getByText: BoundFunction<GetByText>;
@@ -69,7 +70,7 @@ describe('Radio Button', function () {
         const label = radioButton.parentNode as HTMLLabelElement;
         const selectMark = label.querySelector('span span span');
         const borderStyle = window.getComputedStyle(selectMark).border;
-        strictEqual(borderStyle, '6px solid #717171');
+        strictEqual(borderStyle, `6px solid ${MarkOneTheme.color.text.medium}`);
       });
     });
   });

--- a/src/Tables/TableCell.tsx
+++ b/src/Tables/TableCell.tsx
@@ -1,6 +1,6 @@
 import { ReactNode, ReactElement, ForwardRefExoticComponent } from 'react';
 import styled from 'styled-components';
-import { fromTheme, VARIANT } from '../Theme';
+import { fromTheme, TEXTVARIANT } from '../Theme';
 
 /** Represents the possible values for TableCell's text-align property */
 export enum ALIGN {
@@ -29,8 +29,8 @@ export interface TableCellProps {
   verticalAlignment?: VALIGN;
   /** Specifies the background color of the table cell */
   backgroundColor?: string;
-  /** Allows you to pass in a variant property from the VARIANT enum */
-  variant?: VARIANT;
+  /** Allows you to pass in a variant property from the TEXTVARIANT enum */
+  variant?: TEXTVARIANT;
   /** Text or components to be displayed in the cell */
   children: ReactNode;
 }
@@ -41,13 +41,13 @@ const StyledCell = styled.td<TableCellProps>`
   font-family: ${fromTheme('font', 'data', 'family')};
   font-size:  ${fromTheme('font', 'data', 'size')};
   font-weight: ${({ theme, variant }) => (
-    theme.font[(variant === VARIANT.NEGATIVE || variant === VARIANT.MEDIUM)
+    theme.font[(variant === TEXTVARIANT.NEGATIVE || variant === TEXTVARIANT.MEDIUM)
       ? 'bold' : 'base'].weight
   )};
   color: ${({ theme, variant }) => {
-    if (variant === VARIANT.NEGATIVE) {
+    if (variant === TEXTVARIANT.NEGATIVE) {
       return theme.color.text.negative;
-    } else if (variant === VARIANT.MEDIUM) {
+    } else if (variant === TEXTVARIANT.MEDIUM) {
       return theme.color.text.medium;
     } else {
       return theme.color.text.base;
@@ -62,7 +62,7 @@ const StyledCell = styled.td<TableCellProps>`
 StyledCell.defaultProps = {
   alignment: ALIGN.LEFT,
   verticalAlignment: VALIGN.CENTER,
-  variant: VARIANT.BASE,
+  variant: TEXTVARIANT.BASE,
 };
 
 /**

--- a/src/Tables/TableCell.tsx
+++ b/src/Tables/TableCell.tsx
@@ -1,6 +1,6 @@
 import { ReactNode, ReactElement, ForwardRefExoticComponent } from 'react';
 import styled from 'styled-components';
-import { fromTheme } from '../Theme';
+import { fromTheme, VARIANT } from '../Theme';
 
 /** Represents the possible values for TableCell's text-align property */
 export enum ALIGN {
@@ -29,6 +29,8 @@ export interface TableCellProps {
   verticalAlignment?: VALIGN;
   /** Specifies the background color of the table cell */
   backgroundColor?: string;
+  /** Allows you to pass in a variant property from the VARIANT enum */
+  variant?: VARIANT;
   /** Text or components to be displayed in the cell */
   children: ReactNode;
 }
@@ -38,6 +40,12 @@ const StyledCell = styled.td<TableCellProps>`
   border-right: ${fromTheme('border', 'light')};
   font-family: ${fromTheme('font', 'data', 'family')};
   font-size:  ${fromTheme('font', 'data', 'size')};
+  font-weight: ${({ theme, variant }) => (
+    theme.font[variant === VARIANT.NEGATIVE ? 'bold': 'base'].weight
+  )};
+  color: ${({ theme, variant }) => (
+    theme.color.text[variant === VARIANT.NEGATIVE ? 'negative' : 'base']
+  )};
   padding: ${fromTheme('ws', 'xsmall')};
   text-align: ${({ alignment }) => alignment};
   vertical-align: ${({ verticalAlignment }) => verticalAlignment};
@@ -47,6 +55,7 @@ const StyledCell = styled.td<TableCellProps>`
 StyledCell.defaultProps = {
   alignment: ALIGN.LEFT,
   verticalAlignment: VALIGN.CENTER,
+  variant: VARIANT.BASE,
 };
 
 /**

--- a/src/Tables/TableCell.tsx
+++ b/src/Tables/TableCell.tsx
@@ -41,8 +41,8 @@ const StyledCell = styled.td<TableCellProps>`
   font-family: ${fromTheme('font', 'data', 'family')};
   font-size:  ${fromTheme('font', 'data', 'size')};
   font-weight: ${({ theme, variant }) => (
-    theme.font[(variant === TEXT_VARIANT.NEGATIVE
-      || variant === TEXT_VARIANT.MEDIUM)
+    theme.font[[TEXT_VARIANT.NEGATIVE, TEXT_VARIANT.MEDIUM]
+      .includes(variant)
       ? 'bold' : 'base'].weight
   )};
   color: ${({ theme, variant }) => {

--- a/src/Tables/TableCell.tsx
+++ b/src/Tables/TableCell.tsx
@@ -41,17 +41,17 @@ const StyledCell = styled.td<TableCellProps>`
   font-family: ${fromTheme('font', 'data', 'family')};
   font-size:  ${fromTheme('font', 'data', 'size')};
   font-weight: ${({ theme, variant }) => (
-    theme.font[(variant === TEXTVARIANT.NEGATIVE || variant === TEXTVARIANT.MEDIUM)
+    theme.font[(variant === TEXTVARIANT.NEGATIVE
+      || variant === TEXTVARIANT.MEDIUM)
       ? 'bold' : 'base'].weight
   )};
   color: ${({ theme, variant }) => {
     if (variant === TEXTVARIANT.NEGATIVE) {
       return theme.color.text.negative;
-    } else if (variant === TEXTVARIANT.MEDIUM) {
+    } if (variant === TEXTVARIANT.MEDIUM) {
       return theme.color.text.medium;
-    } else {
-      return theme.color.text.base;
     }
+    return theme.color.text.base;
   }};
   padding: ${fromTheme('ws', 'xsmall')};
   text-align: ${({ alignment }) => alignment};

--- a/src/Tables/TableCell.tsx
+++ b/src/Tables/TableCell.tsx
@@ -41,11 +41,18 @@ const StyledCell = styled.td<TableCellProps>`
   font-family: ${fromTheme('font', 'data', 'family')};
   font-size:  ${fromTheme('font', 'data', 'size')};
   font-weight: ${({ theme, variant }) => (
-    theme.font[variant === VARIANT.NEGATIVE ? 'bold': 'base'].weight
+    theme.font[(variant === VARIANT.NEGATIVE || variant === VARIANT.MEDIUM)
+      ? 'bold' : 'base'].weight
   )};
-  color: ${({ theme, variant }) => (
-    theme.color.text[variant === VARIANT.NEGATIVE ? 'negative' : 'base']
-  )};
+  color: ${({ theme, variant }) => {
+    if (variant === VARIANT.NEGATIVE) {
+      return theme.color.text.negative;
+    } else if (variant === VARIANT.MEDIUM) {
+      return theme.color.text.medium;
+    } else {
+      return theme.color.text.base;
+    }
+  }};
   padding: ${fromTheme('ws', 'xsmall')};
   text-align: ${({ alignment }) => alignment};
   vertical-align: ${({ verticalAlignment }) => verticalAlignment};

--- a/src/Tables/TableCell.tsx
+++ b/src/Tables/TableCell.tsx
@@ -1,6 +1,6 @@
 import { ReactNode, ReactElement, ForwardRefExoticComponent } from 'react';
 import styled from 'styled-components';
-import { fromTheme, TEXTVARIANT } from '../Theme';
+import { fromTheme, TEXT_VARIANT } from '../Theme';
 
 /** Represents the possible values for TableCell's text-align property */
 export enum ALIGN {
@@ -29,8 +29,8 @@ export interface TableCellProps {
   verticalAlignment?: VALIGN;
   /** Specifies the background color of the table cell */
   backgroundColor?: string;
-  /** Allows you to pass in a variant property from the TEXTVARIANT enum */
-  variant?: TEXTVARIANT;
+  /** Allows you to pass in a variant property from the TEXT_VARIANT enum */
+  variant?: TEXT_VARIANT;
   /** Text or components to be displayed in the cell */
   children: ReactNode;
 }
@@ -41,14 +41,14 @@ const StyledCell = styled.td<TableCellProps>`
   font-family: ${fromTheme('font', 'data', 'family')};
   font-size:  ${fromTheme('font', 'data', 'size')};
   font-weight: ${({ theme, variant }) => (
-    theme.font[(variant === TEXTVARIANT.NEGATIVE
-      || variant === TEXTVARIANT.MEDIUM)
+    theme.font[(variant === TEXT_VARIANT.NEGATIVE
+      || variant === TEXT_VARIANT.MEDIUM)
       ? 'bold' : 'base'].weight
   )};
   color: ${({ theme, variant }) => {
-    if (variant === TEXTVARIANT.NEGATIVE) {
+    if (variant === TEXT_VARIANT.NEGATIVE) {
       return theme.color.text.negative;
-    } if (variant === TEXTVARIANT.MEDIUM) {
+    } if (variant === TEXT_VARIANT.MEDIUM) {
       return theme.color.text.medium;
     }
     return theme.color.text.base;
@@ -62,7 +62,7 @@ const StyledCell = styled.td<TableCellProps>`
 StyledCell.defaultProps = {
   alignment: ALIGN.LEFT,
   verticalAlignment: VALIGN.CENTER,
-  variant: TEXTVARIANT.BASE,
+  variant: TEXT_VARIANT.BASE,
 };
 
 /**

--- a/src/Tables/TableCell.tsx
+++ b/src/Tables/TableCell.tsx
@@ -43,7 +43,7 @@ const StyledCell = styled.td<TableCellProps>`
   font-weight: ${({ theme, variant }) => (
     theme.font[[TEXT_VARIANT.NEGATIVE, TEXT_VARIANT.MEDIUM]
       .includes(variant)
-      ? 'bold' : 'base'].weight
+      ? 'bold' : 'data'].weight
   )};
   color: ${({ theme, variant }) => {
     if (variant === TEXT_VARIANT.NEGATIVE) {

--- a/src/Tables/__tests__/Table.test.tsx
+++ b/src/Tables/__tests__/Table.test.tsx
@@ -165,7 +165,7 @@ describe('Table Components', function () {
     it('defaults to medium with no background color', function () {
       const style = window.getComputedStyle(getByText('Without Background'));
       const [red, green, blue] = convert.hex.rgb(
-        MarkOneTheme.color.background.medium
+        `${MarkOneTheme.color.background.medium}`
       );
       const convertExpectedToRGB = `rgb(${red}, ${green}, ${blue})`;
       strictEqual(style.backgroundColor, convertExpectedToRGB);

--- a/src/Tables/__tests__/Table.test.tsx
+++ b/src/Tables/__tests__/Table.test.tsx
@@ -99,7 +99,7 @@ describe('Table Components', function () {
       });
       it('renders the cell content with the base text font weight', function () {
         const style = window.getComputedStyle(getByText('3'));
-        strictEqual(style.fontWeight, WEIGHT.MEDIUM);
+        strictEqual(style.fontWeight, MarkOneTheme.font.base.weight);
       });
     });
     context('when variant prop value is VARIANT.NEGATIVE', function () {
@@ -113,7 +113,7 @@ describe('Table Components', function () {
       });
       it('renders the cell content with the bold font weight', function () {
         const style = window.getComputedStyle(getByText('Jess'));
-        strictEqual(style.fontWeight, WEIGHT.BOLD);
+        strictEqual(style.fontWeight, MarkOneTheme.font.bold.weight);
       });
     });
     context('when variant prop value is VARIANT.MEDIUM', function () {
@@ -127,7 +127,7 @@ describe('Table Components', function () {
       });
       it('renders the cell content with the bold font weight', function () {
         const style = window.getComputedStyle(getByText('2'));
-        strictEqual(style.fontWeight, WEIGHT.BOLD);
+        strictEqual(style.fontWeight, MarkOneTheme.font.bold.weight);
       });
     });
   });

--- a/src/Tables/__tests__/Table.test.tsx
+++ b/src/Tables/__tests__/Table.test.tsx
@@ -34,7 +34,12 @@ describe('Table Components', function () {
             <TableCell>Bernstein</TableCell>
           </TableRow>
           <TableRow>
-            <TableCell alignment={ALIGN.LEFT}>2</TableCell>
+            <TableCell
+              alignment={ALIGN.LEFT}
+              variant={VARIANT.MEDIUM}
+            >
+              2
+            </TableCell>
             <TableCell
               alignment={ALIGN.LEFT}
               variant={VARIANT.NEGATIVE}
@@ -85,7 +90,7 @@ describe('Table Components', function () {
     });
     context('when variant prop value is not specified', function () {
       it('renders the cell content with the base text font color', function () {
-        const style = window.getComputedStyle(getByText('2'));
+        const style = window.getComputedStyle(getByText('3'));
         const [red, green, blue] = convert.hex.rgb(
           MarkOneTheme.color.text.base
         );
@@ -93,7 +98,7 @@ describe('Table Components', function () {
         strictEqual(style.color, convertExpectedToRGB);
       });
       it('renders the cell content with the base text font weight', function () {
-        const style = window.getComputedStyle(getByText('2'));
+        const style = window.getComputedStyle(getByText('3'));
         strictEqual(style.fontWeight, WEIGHT.MEDIUM);
       });
     });
@@ -106,12 +111,26 @@ describe('Table Components', function () {
         const convertExpectedToRGB = `rgb(${red}, ${green}, ${blue})`;
         strictEqual(style.color, convertExpectedToRGB);
       });
-      it('renders the cell content with the base text font weight', function () {
+      it('renders the cell content with the bold font weight', function () {
         const style = window.getComputedStyle(getByText('Jess'));
         strictEqual(style.fontWeight, WEIGHT.BOLD);
       });
     });
-    context('when variant prop value is set to a non-VARIANT.NEGATIVE variant value', function () {
+    context('when variant prop value is VARIANT.MEDIUM', function () {
+      it('renders the cell content with the medium text font color', function () {
+        const style = window.getComputedStyle(getByText('2'));
+        const [red, green, blue] = convert.hex.rgb(
+          MarkOneTheme.color.text.medium
+        );
+        const convertExpectedToRGB = `rgb(${red}, ${green}, ${blue})`;
+        strictEqual(style.color, convertExpectedToRGB);
+      });
+      it('renders the cell content with the bold font weight', function () {
+        const style = window.getComputedStyle(getByText('2'));
+        strictEqual(style.fontWeight, WEIGHT.BOLD);
+      });
+    });
+    context('when variant prop value is set to a non-VARIANT.NEGATIVE and non-VARIANT.MEDIUM variant value', function () {
       it('renders the cell content with the base text font color', function () {
         const style = window.getComputedStyle(getByText('Win'));
         const [red, green, blue] = convert.hex.rgb(

--- a/src/Tables/__tests__/Table.test.tsx
+++ b/src/Tables/__tests__/Table.test.tsx
@@ -4,13 +4,14 @@ import {
 } from 'test-utils';
 import convert from 'color-convert';
 import { strictEqual } from 'assert';
+import { VARIANT } from 'Theme';
 import TableCell, { ALIGN } from '../TableCell';
 import TableBody from '../TableBody';
 import TableHead from '../TableHead';
 import TableHeadingCell from '../TableHeadingCell';
 import TableRow from '../TableRow';
 import Table from '../Table';
-import MarkOneTheme from '../../Theme/MarkOneTheme';
+import MarkOneTheme, { WEIGHT } from '../../Theme/MarkOneTheme';
 
 describe('Table Components', function () {
   let getByText: BoundFunction<GetByText>;
@@ -34,8 +35,18 @@ describe('Table Components', function () {
           </TableRow>
           <TableRow>
             <TableCell alignment={ALIGN.LEFT}>2</TableCell>
-            <TableCell alignment={ALIGN.LEFT}>Jess</TableCell>
-            <TableCell alignment={ALIGN.LEFT}>Win</TableCell>
+            <TableCell
+              alignment={ALIGN.LEFT}
+              variant={VARIANT.NEGATIVE}
+            >
+              Jess
+            </TableCell>
+            <TableCell
+              alignment={ALIGN.LEFT}
+              variant={VARIANT.POSITIVE}
+            >
+              Win
+            </TableCell>
           </TableRow>
           <TableRow isStriped>
             <TableCell alignment={ALIGN.CENTER}>3</TableCell>
@@ -71,6 +82,36 @@ describe('Table Components', function () {
     it('renders the correct background color', function () {
       const style = window.getComputedStyle(getByText('1'));
       strictEqual(style.backgroundColor, 'rgb(135, 255, 0)');
+    });
+    context('when variant prop value is not specified', function () {
+      it('renders the cell content with the base text font color', function () {
+        const style = window.getComputedStyle(getByText('2'));
+        strictEqual(style.color, 'rgb(24, 24, 24)');
+      });
+      it('renders the cell content with the base text font weight', function () {
+        const style = window.getComputedStyle(getByText('2'));
+        strictEqual(style.fontWeight, WEIGHT.MEDIUM);
+      });
+    });
+    context('when variant prop value is VARIANT.NEGATIVE', function () {
+      it('renders the cell content with the negative text font color', function () {
+        const style = window.getComputedStyle(getByText('Jess'));
+        strictEqual(style.color, 'rgb(201, 34, 59)');
+      });
+      it('renders the cell content with the base text font weight', function () {
+        const style = window.getComputedStyle(getByText('Jess'));
+        strictEqual(style.fontWeight, WEIGHT.BOLD);
+      });
+    });
+    context('when variant prop value is set to a non-VARIANT.NEGATIVE variant value', function () {
+      it('renders the cell content with the base text font color', function () {
+        const style = window.getComputedStyle(getByText('Win'));
+        strictEqual(style.color, 'rgb(24, 24, 24)');
+      });
+      it('renders the cell content with the base text font weight', function () {
+        const style = window.getComputedStyle(getByText('Win'));
+        strictEqual(style.fontWeight, WEIGHT.MEDIUM);
+      });
     });
   });
   describe('Table Heading Cell', function () {

--- a/src/Tables/__tests__/Table.test.tsx
+++ b/src/Tables/__tests__/Table.test.tsx
@@ -4,7 +4,7 @@ import {
 } from 'test-utils';
 import convert from 'color-convert';
 import { strictEqual } from 'assert';
-import { VARIANT } from 'Theme';
+import { TEXTVARIANT } from 'Theme';
 import TableCell, { ALIGN } from '../TableCell';
 import TableBody from '../TableBody';
 import TableHead from '../TableHead';
@@ -36,19 +36,19 @@ describe('Table Components', function () {
           <TableRow>
             <TableCell
               alignment={ALIGN.LEFT}
-              variant={VARIANT.MEDIUM}
+              variant={TEXTVARIANT.MEDIUM}
             >
               2
             </TableCell>
             <TableCell
               alignment={ALIGN.LEFT}
-              variant={VARIANT.NEGATIVE}
+              variant={TEXTVARIANT.NEGATIVE}
             >
               Jess
             </TableCell>
             <TableCell
               alignment={ALIGN.LEFT}
-              variant={VARIANT.POSITIVE}
+              variant={TEXTVARIANT.NEGATIVE}
             >
               Win
             </TableCell>
@@ -130,20 +130,6 @@ describe('Table Components', function () {
         strictEqual(style.fontWeight, WEIGHT.BOLD);
       });
     });
-    context('when variant prop value is set to a non-VARIANT.NEGATIVE and non-VARIANT.MEDIUM variant value', function () {
-      it('renders the cell content with the base text font color', function () {
-        const style = window.getComputedStyle(getByText('Win'));
-        const [red, green, blue] = convert.hex.rgb(
-          MarkOneTheme.color.text.base
-        );
-        const convertExpectedToRGB = `rgb(${red}, ${green}, ${blue})`;
-        strictEqual(style.color, convertExpectedToRGB);
-      });
-      it('renders the cell content with the base text font weight', function () {
-        const style = window.getComputedStyle(getByText('Win'));
-        strictEqual(style.fontWeight, WEIGHT.MEDIUM);
-      });
-    });
   });
   describe('Table Heading Cell', function () {
     beforeEach(function () {
@@ -165,7 +151,7 @@ describe('Table Components', function () {
     it('defaults to medium with no background color', function () {
       const style = window.getComputedStyle(getByText('Without Background'));
       const [red, green, blue] = convert.hex.rgb(
-        `${MarkOneTheme.color.background.medium}`
+        MarkOneTheme.color.background.medium
       );
       const convertExpectedToRGB = `rgb(${red}, ${green}, ${blue})`;
       strictEqual(style.backgroundColor, convertExpectedToRGB);

--- a/src/Tables/__tests__/Table.test.tsx
+++ b/src/Tables/__tests__/Table.test.tsx
@@ -11,7 +11,7 @@ import TableHead from '../TableHead';
 import TableHeadingCell from '../TableHeadingCell';
 import TableRow from '../TableRow';
 import Table from '../Table';
-import MarkOneTheme, { WEIGHT } from '../../Theme/MarkOneTheme';
+import MarkOneTheme from '../../Theme/MarkOneTheme';
 
 describe('Table Components', function () {
   let getByText: BoundFunction<GetByText>;

--- a/src/Tables/__tests__/Table.test.tsx
+++ b/src/Tables/__tests__/Table.test.tsx
@@ -4,7 +4,7 @@ import {
 } from 'test-utils';
 import convert from 'color-convert';
 import { strictEqual } from 'assert';
-import { TEXTVARIANT } from 'Theme';
+import { TEXT_VARIANT } from 'Theme';
 import TableCell, { ALIGN } from '../TableCell';
 import TableBody from '../TableBody';
 import TableHead from '../TableHead';
@@ -36,19 +36,19 @@ describe('Table Components', function () {
           <TableRow>
             <TableCell
               alignment={ALIGN.LEFT}
-              variant={TEXTVARIANT.MEDIUM}
+              variant={TEXT_VARIANT.MEDIUM}
             >
               2
             </TableCell>
             <TableCell
               alignment={ALIGN.LEFT}
-              variant={TEXTVARIANT.NEGATIVE}
+              variant={TEXT_VARIANT.NEGATIVE}
             >
               Jess
             </TableCell>
             <TableCell
               alignment={ALIGN.LEFT}
-              variant={TEXTVARIANT.NEGATIVE}
+              variant={TEXT_VARIANT.NEGATIVE}
             >
               Win
             </TableCell>

--- a/src/Tables/__tests__/Table.test.tsx
+++ b/src/Tables/__tests__/Table.test.tsx
@@ -86,7 +86,11 @@ describe('Table Components', function () {
     context('when variant prop value is not specified', function () {
       it('renders the cell content with the base text font color', function () {
         const style = window.getComputedStyle(getByText('2'));
-        strictEqual(style.color, 'rgb(24, 24, 24)');
+        const [red, green, blue] = convert.hex.rgb(
+          MarkOneTheme.color.text.base
+        );
+        const convertExpectedToRGB = `rgb(${red}, ${green}, ${blue})`;
+        strictEqual(style.color, convertExpectedToRGB);
       });
       it('renders the cell content with the base text font weight', function () {
         const style = window.getComputedStyle(getByText('2'));
@@ -96,7 +100,11 @@ describe('Table Components', function () {
     context('when variant prop value is VARIANT.NEGATIVE', function () {
       it('renders the cell content with the negative text font color', function () {
         const style = window.getComputedStyle(getByText('Jess'));
-        strictEqual(style.color, 'rgb(201, 34, 59)');
+        const [red, green, blue] = convert.hex.rgb(
+          MarkOneTheme.color.text.negative
+        );
+        const convertExpectedToRGB = `rgb(${red}, ${green}, ${blue})`;
+        strictEqual(style.color, convertExpectedToRGB);
       });
       it('renders the cell content with the base text font weight', function () {
         const style = window.getComputedStyle(getByText('Jess'));
@@ -106,7 +114,11 @@ describe('Table Components', function () {
     context('when variant prop value is set to a non-VARIANT.NEGATIVE variant value', function () {
       it('renders the cell content with the base text font color', function () {
         const style = window.getComputedStyle(getByText('Win'));
-        strictEqual(style.color, 'rgb(24, 24, 24)');
+        const [red, green, blue] = convert.hex.rgb(
+          MarkOneTheme.color.text.base
+        );
+        const convertExpectedToRGB = `rgb(${red}, ${green}, ${blue})`;
+        strictEqual(style.color, convertExpectedToRGB);
       });
       it('renders the cell content with the base text font weight', function () {
         const style = window.getComputedStyle(getByText('Win'));

--- a/src/Theme/MarkOneTheme.ts
+++ b/src/Theme/MarkOneTheme.ts
@@ -6,7 +6,7 @@ enum FONT {
   MONO = '"Roboto Mono", monospace',
 }
 
-enum WEIGHT {
+export enum WEIGHT {
   LIGHT = '300',
   MEDIUM = '400',
   BOLD = '600',

--- a/src/Theme/MarkOneTheme.ts
+++ b/src/Theme/MarkOneTheme.ts
@@ -48,11 +48,11 @@ const MarkOneTheme: DefaultTheme = {
     text: {
       base: BLACK,
       light: lighten(0.9, BLACK),
-      medium: lighten(0.35, BLACK),
+      medium: '#575757',
       dark: BLACK,
       info: '#4e88c7',
       positive: '#4db848',
-      negative: '#c9223b',
+      negative: '#a61c31',
     },
     area: {
       acs: '#da373e',

--- a/src/Theme/MarkOneTheme.ts
+++ b/src/Theme/MarkOneTheme.ts
@@ -83,7 +83,7 @@ const MarkOneTheme: DefaultTheme = {
     data: {
       family: FONT.MONO,
       size: '0.9em',
-      weight: WEIGHT.BOLD,
+      weight: WEIGHT.MEDIUM,
     },
     note: {
       family: FONT.SANS,

--- a/src/Theme/MarkOneTheme.ts
+++ b/src/Theme/MarkOneTheme.ts
@@ -52,7 +52,7 @@ const MarkOneTheme: DefaultTheme = {
       dark: BLACK,
       info: '#4e88c7',
       positive: '#4db848',
-      negative: '#ff4040',
+      negative: '#c9223b',
     },
     area: {
       acs: '#da373e',

--- a/src/Theme/MarkOneTheme.ts
+++ b/src/Theme/MarkOneTheme.ts
@@ -52,7 +52,7 @@ const MarkOneTheme: DefaultTheme = {
       dark: BLACK,
       info: '#4e88c7',
       positive: '#4db848',
-      negative: '#a61c31',
+      negative: '#bd0f24',
     },
     area: {
       acs: '#da373e',

--- a/src/Theme/MarkOneTheme.ts
+++ b/src/Theme/MarkOneTheme.ts
@@ -6,7 +6,7 @@ enum FONT {
   MONO = '"Roboto Mono", monospace',
 }
 
-export enum WEIGHT {
+enum WEIGHT {
   LIGHT = '300',
   MEDIUM = '400',
   BOLD = '600',

--- a/src/Theme/MarkOneTheme.ts
+++ b/src/Theme/MarkOneTheme.ts
@@ -19,8 +19,8 @@ const MarkOneTheme: DefaultTheme = {
   color: {
     background: {
       light: WHITE,
-      subtle: darken(0.07, WHITE),
-      medium: darken(0.175, WHITE),
+      subtle: '#f2f2f2',
+      medium: '#e8e8e8',
       dark: '#93a1ad',
       darker: darken(0.75, WHITE),
       accent: '#a51c30',

--- a/src/Theme/ThemeTypes.ts
+++ b/src/Theme/ThemeTypes.ts
@@ -1,6 +1,6 @@
 export type ColorRange = {
   light: string;
-  medium: string;
+  medium?: string;
   subtle?: string;
   dark: string;
   darker?: string;

--- a/src/Theme/ThemeTypes.ts
+++ b/src/Theme/ThemeTypes.ts
@@ -1,6 +1,6 @@
 export type ColorRange = {
   light: string;
-  medium?: string;
+  medium: string;
   subtle?: string;
   dark: string;
   darker?: string;

--- a/src/Theme/utils.ts
+++ b/src/Theme/utils.ts
@@ -113,5 +113,13 @@ export enum VARIANT {
   SECONDARY = 'base',
   DANGER = 'negative',
   DEFAULT = 'base',
+}
+
+/**
+ * A set of enums used for the text variations within a TableCell component
+ */
+export enum TEXTVARIANT {
   MEDIUM = 'medium',
+  NEGATIVE = 'negative',
+  BASE = 'base',
 }

--- a/src/Theme/utils.ts
+++ b/src/Theme/utils.ts
@@ -113,4 +113,5 @@ export enum VARIANT {
   SECONDARY = 'base',
   DANGER = 'negative',
   DEFAULT = 'base',
+  MEDIUM = 'medium',
 }

--- a/src/Theme/utils.ts
+++ b/src/Theme/utils.ts
@@ -118,7 +118,7 @@ export enum VARIANT {
 /**
  * A set of enums used for the text variations within a TableCell component
  */
-export enum TEXTVARIANT {
+export enum TEXT_VARIANT {
   MEDIUM = 'medium',
   NEGATIVE = 'negative',
   BASE = 'base',


### PR DESCRIPTION
This PR adds text styling to the contents within a table cell. The `medium` and `negative` `text` colors in the theme were updated per accessibility (color contrast) recommendations from Vittorio in ticket [#300](https://github.com/seas-computing/course-planner/issues/300). I added an optional `variant` property to the `TableCell` so that users can use the `VARIANT.MEDIUM` (which we will use for "No Longer Active" faculty absence fields in Course Planner) styling and `VARIANT.NEGATIVE` (which we will use for other faculty absences that need attention in Course Planner) styling. If the user does not specify a variant, the text `font-weight` and `color` will default to the theme's `base` color and `medium` weight, which is how all table cells were styled originally before this ticket.

## Describe your changes
<!--
  In a few sentences, explain what your charges will do if merged. You can also
  use this space to ask any questions about your changes, highlight particular 
  issues, and provide any additional information about how to run and/or test 
  your code.
-->

## Types of changes
<!--
  What types of changes does your code introduce? Put an `x` in all the boxes
  that apply:
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
<!--
  Go over all the following points, and put an `x` in all the boxes that apply.
-->
- [x] I have run `eslint` on the code
- [x] I have added JSDoc for all of my code (where applicable)
- [x] I have added tests to cover my changes.

## Priority:
- [x] Normal <!-- New piece of functionality -->
- [ ] High <!-- Critical bug requiring urgent review -->

## Related Issues:
<!--
  Add the issue number in below that this PR is intended to address.

  Also mention any issues that this PR is related to, and if possible,
  provide more information regarding the relationship to the issues in
  question (i.e does the PR fix the issue, is it designed to fix another bug
  that is similar to the issue etc.)
-->
Fixes [#300](https://github.com/seas-computing/course-planner/issues/300)

<!--
  Attribution:
  PR Template adapted from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
