### PR TITLE
Update import statement of fromTheme to use a relative path

### DIFF
--- a/src/Forms/Fieldset.tsx
+++ b/src/Forms/Fieldset.tsx
@@ -6,7 +6,7 @@ import React,
   useContext,
 } from 'react';
 import styled, { ThemeContext } from 'styled-components';
-import { fromTheme } from 'Theme';
+import { fromTheme } from '../Theme';
 import { NoteText } from '../Typography';
 import ValidationErrorMessage from './ValidationErrorMessage';
 import { RequiredSymbol } from './InputLabel';


### PR DESCRIPTION
I was having issues with bringing up the Course Planner app with the latest code in `develop.` This is the error that I was getting:
![image](https://user-images.githubusercontent.com/29589689/108398939-8fdde480-71e7-11eb-8dc0-87f7a406ccf6.png)

The issue appears to be that we were not using a relative path when importing `fromTheme` in `Fieldset.` `Fieldset` was updated to import `fromTheme` from `../Theme` instead of `Theme`.

## Describe your changes
<!--
  In a few sentences, explain what your charges will do if merged. You can also
  use this space to ask any questions about your changes, highlight particular 
  issues, and provide any additional information about how to run and/or test 
  your code.
-->

## Types of changes
<!--
  What types of changes does your code introduce? Put an `x` in all the boxes
  that apply:
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
<!--
  Go over all the following points, and put an `x` in all the boxes that apply.
-->
- [x] I have run `eslint` on the code
- [ ] I have added JSDoc for all of my code (where applicable)
- [ ] I have added tests to cover my changes.

## Priority:
- [x] Normal <!-- New piece of functionality -->
- [ ] High <!-- Critical bug requiring urgent review -->

## Related Issues:
<!--
  Add the issue number in below that this PR is intended to address.

  Also mention any issues that this PR is related to, and if possible,
  provide more information regarding the relationship to the issues in
  question (i.e does the PR fix the issue, is it designed to fix another bug
  that is similar to the issue etc.)
-->
Fixes #274

<!--
  Attribution:
  PR Template adapted from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
