### PR TITLE
Add :disabled styles to buttons

### DIFF
--- a/examples/Buttons/BorderlessButton.md
+++ b/examples/Buttons/BorderlessButton.md
@@ -83,6 +83,48 @@ import { faTrash } from '@fortawesome/free-solid-svg-icons';
 </BorderlessButton>
 ```
 
+### With the `disabled` prop
+
+This shows the full set of buttons in "active" mode alongside the buttons in "disabled" mode:
+
+```jsx
+import { VARIANT } from 'mark-one';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faCheck, faTimes } from '@fortawesome/free-solid-svg-icons';
+import styled from 'styled-components';
+
+const TwoUpBox = styled.div`
+  display: flex;
+  justify-content: space-around;
+  padding: 1em;
+  border-bottom: ${({theme}) => (theme.border.hairline)}
+`;
+
+<>
+  {Object.keys(VARIANT).map((variantName) => (
+    <TwoUpBox key={variantName}>
+      <BorderlessButton
+        variant={VARIANT[variantName]}
+        onClick={() => {}}
+        title={`Active ${variantName}`}
+      >
+        <FontAwesomeIcon icon={faCheck} size="lg" />
+      </BorderlessButton>
+      <strong>{variantName}</strong>
+      <BorderlessButton
+        variant={VARIANT[variantName]}
+        onClick={() => {}}
+        disabled
+        title={`Disabled ${variantName}`}
+      >
+        <FontAwesomeIcon icon={faTimes} size="lg" />
+      </BorderlessButton>
+    </TwoUpBox>
+  ))}
+</>
+
+```
+
 ### With the `forwardRef`
 Ref example: The optional `forwardRef` property is set. When the primary themed button is clicked, the focus shifts to the borderless button.
 ```jsx

--- a/examples/Buttons/Button.md
+++ b/examples/Buttons/Button.md
@@ -72,6 +72,44 @@ import { VARIANT } from 'mark-one';
 </Button>
 ```
 
+### With the `disabled` prop
+
+This shows the full set of buttons in "active" mode alongside the buttons in "disabled" mode:
+
+```jsx
+import { VARIANT } from 'mark-one';
+import styled from 'styled-components';
+
+const TwoUpBox = styled.div`
+  display: flex;
+  justify-content: space-around;
+  padding: 1em;
+  border-bottom: ${({theme}) => (theme.border.hairline)}
+`;
+
+<>
+  {Object.keys(VARIANT).map((variantName) => (
+    <TwoUpBox key={variantName}>
+      <Button
+        variant={VARIANT[variantName]}
+        onClick={() => {}}
+      >
+        {`Active`}
+      </Button>
+      <strong>{variantName}</strong>
+      <Button
+        variant={VARIANT[variantName]}
+        onClick={() => {}}
+        disabled
+      >
+        {`Disabled`}
+      </Button>
+    </TwoUpBox>
+  ))}
+</>
+
+```
+
 ### With the `forwardRef`
 Ref example: The optional `forwardRef` property is set. When the primary themed button is clicked, the focus shifts to the borderless button.
 ```jsx

--- a/src/Buttons/BorderlessButton.tsx
+++ b/src/Buttons/BorderlessButton.tsx
@@ -34,6 +34,11 @@ const StyledBorderlessButton = styled.button<BorderlessButtonProps>`
     background: transparent;
     color: ${({ variant, theme }) => theme.color.background[variant].dark};
   }
+  &:disabled {
+    cursor: not-allowed;
+    color: ${({ theme, variant }) => theme.color.background[variant].medium};
+    opacity: 0.66;
+  }
 `;
 
 StyledBorderlessButton.defaultProps = {

--- a/src/Buttons/Button.tsx
+++ b/src/Buttons/Button.tsx
@@ -42,6 +42,11 @@ const StyledButton = styled.button<ButtonProps>`
     theme.color.text[variant === VARIANT.BASE ? 'dark' : 'light']
   )};
   }
+  &:disabled {
+    cursor: not-allowed;
+    background: ${({ theme, variant }) => theme.color.background[variant].medium};
+    opacity: 0.66;
+  }
 `;
 
 StyledButton.defaultProps = {


### PR DESCRIPTION
## Describe your changes

The original button implementation had a disabled prop that prevented the onClick handler from being called, but did not include any stylistic changes to indicate to the user that the button was disabled. In fact the `:hover` and `:active` pseudo-classes were still being applied so it appeared as through the button was clicked but nothing was happening. This adds some additional style rules to the `:disabled` pseudo-class to provide visual cues to the user that the button is disabled.

## Types of changes
<!--
  What types of changes does your code introduce? Put an `x` in all the boxes
  that apply:
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
<!--
  Go over all the following points, and put an `x` in all the boxes that apply.
-->
- [x] I have run `eslint` on the code
- [x] I have added JSDoc for all of my code (where applicable)
- [x] I have added tests to cover my changes.

## Priority:
- [x] Normal <!-- New piece of functionality -->
- [ ] High <!-- Critical bug requiring urgent review -->

## Related Issues:
<!--
  Add the issue number in below that this PR is intended to address.

  Also mention any issues that this PR is related to, and if possible,
  provide more information regarding the relationship to the issues in
  question (i.e does the PR fix the issue, is it designed to fix another bug
  that is similar to the issue etc.)
-->
Fixes #109

<!--
  Attribution:
  PR Template adapted from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
