### PR TITLE
Remove font-family property from TableCell and TableRowHeadingCell

### DIFF
--- a/src/Tables/TableCell.tsx
+++ b/src/Tables/TableCell.tsx
@@ -38,7 +38,6 @@ export interface TableCellProps {
 const StyledCell = styled.td<TableCellProps>`
   border-left: ${fromTheme('border', 'light')};
   border-right: ${fromTheme('border', 'light')};
-  font-family: ${fromTheme('font', 'data', 'family')};
   font-size:  ${fromTheme('font', 'data', 'size')};
   font-weight: ${({ theme, variant }) => (
     theme.font[[TEXT_VARIANT.NEGATIVE, TEXT_VARIANT.MEDIUM]

--- a/src/Tables/TableRowHeadingCell.tsx
+++ b/src/Tables/TableRowHeadingCell.tsx
@@ -26,7 +26,6 @@ const StyledTableRowHeadingCell = styled.th<TableRowHeadingCellProps>`
   border-left: ${fromTheme('border', 'light')};
   border-right: ${fromTheme('border', 'light')};
   font-weight: ${fromTheme('font', 'data', 'weight')};
-  font-family: ${fromTheme('font', 'data', 'family')};
   font-size: ${fromTheme('font', 'data', 'size')};
   text-align: ${({ alignment }) => alignment};
   vertical-align: ${({ verticalAlignment }) => verticalAlignment};


### PR DESCRIPTION
This PR removes the font-family property from the `TableCell` and `TableRowHeadingCell` components. The font-family will instead be inherited from the components' parents. This way, the font of the table data in Course Planner should be sans-serif. 

## Describe your changes
<!--
  In a few sentences, explain what your charges will do if merged. You can also
  use this space to ask any questions about your changes, highlight particular 
  issues, and provide any additional information about how to run and/or test 
  your code.
-->

## Types of changes
<!--
  What types of changes does your code introduce? Put an `x` in all the boxes
  that apply:
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
<!--
  Go over all the following points, and put an `x` in all the boxes that apply.
-->
- [x] I have run `eslint` on the code
- [ ] I have added JSDoc for all of my code (where applicable)
- [ ] I have added tests to cover my changes.

## Priority:
- [x] Normal <!-- New piece of functionality -->
- [ ] High <!-- Critical bug requiring urgent review -->

## Related Issues:
<!--
  Add the issue number in below that this PR is intended to address.

  Also mention any issues that this PR is related to, and if possible,
  provide more information regarding the relationship to the issues in
  question (i.e does the PR fix the issue, is it designed to fix another bug
  that is similar to the issue etc.)
-->
Fixes [#386](https://github.com/seas-computing/course-planner/issues/386)

<!--
  Attribution:
  PR Template adapted from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
