### PR TITLE
Create generic list components

### DIFF
--- a/examples/Lists/List.md
+++ b/examples/Lists/List.md
@@ -1,0 +1,26 @@
+The `<List>` and `<ListItem>` components can be used to render an ordered or unordered list of elements. Both list styles are visually identical, but should be specified for proper html semantics.
+
+The ordered version of the list: 
+
+```tsx
+import { List, ListItem } from 'mark-one';
+
+<List ordered>
+  <ListItem>One</ListItem>
+  <ListItem>Two</ListItem>
+  <ListItem>Three</ListItem>
+</List>
+```
+
+And the unordered version of the list: 
+
+```tsx
+import { List, ListItem } from 'mark-one';
+
+<List>
+  <ListItem>Dogs</ListItem>
+  <ListItem>Cats</ListItem>
+  <ListItem>Fish</ListItem>
+</List>
+```
+

--- a/src/Lists/List.tsx
+++ b/src/Lists/List.tsx
@@ -1,0 +1,42 @@
+import styled from 'styled-components';
+import ListItem from './ListItem';
+import { fromTheme } from '../Theme';
+
+export interface ListProps {
+  /**
+   * Should only contain ListItems
+   */
+  children: ListItem | ListItem[];
+  /**
+  * Whether this list is ordered (true) or unordered (false)
+  */
+  ordered?: boolean;
+}
+
+/**
+* Renders either an ordered or unordered list component, depending on the value
+* of the "ordered" prop. Both list types are styled identically, but the
+* difference is important semantically
+*/
+
+const List = styled.ol.attrs(
+  ({ ordered }: ListProps) => (
+    {
+      as: ordered ? 'ol' : 'ul',
+    }
+  )
+)<ListProps>`
+  list-style: none;
+  > li {
+    border-top: ${fromTheme('border', 'hairline')};
+    &:first-child {
+      border-top: none;
+    }
+  }
+`;
+
+List.defaultProps = {
+  ordered: false,
+};
+
+export default List;

--- a/src/Lists/ListItem.tsx
+++ b/src/Lists/ListItem.tsx
@@ -1,0 +1,21 @@
+import { ReactElement, ReactNode } from 'react';
+import styled from 'styled-components';
+import { fromTheme } from '../Theme';
+
+export interface ListItemProps {
+  /**
+   * The contents of the list item
+   */
+  children: ReactNode;
+}
+
+/**
+* The items to be displayed inside of the List component.
+*/
+const ListItem = styled.li<ListItemProps>`
+  padding: ${fromTheme('ws', 'small')} 0px;
+`;
+
+declare type ListItem = ReactElement<ListItemProps>;
+
+export default ListItem;

--- a/src/Lists/__tests__/List.test.tsx
+++ b/src/Lists/__tests__/List.test.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { render } from 'test-utils';
+import { strictEqual } from 'assert';
+import List from '../List';
+import ListItem from '../ListItem';
+
+describe('List', function () {
+  describe('Ordering', function () {
+    context('With the ordered prop', function () {
+      it('Should use an <ol> element', function () {
+        const { getByRole } = render(
+          <List ordered>
+            <ListItem>One</ListItem>
+            <ListItem>Two</ListItem>
+            <ListItem>Three</ListItem>
+          </List>
+        );
+        const listElement = getByRole('list');
+        strictEqual(listElement.tagName, 'OL');
+      });
+    });
+    context('Without the ordered prop', function () {
+      it('Should use an <ul> element', function () {
+        const { getByRole } = render(
+          <List>
+            <ListItem>Dogs</ListItem>
+            <ListItem>Cats</ListItem>
+            <ListItem>Fish</ListItem>
+          </List>
+        );
+        const listElement = getByRole('list');
+        strictEqual(listElement.tagName, 'UL');
+      });
+    });
+  });
+});

--- a/src/Lists/index.ts
+++ b/src/Lists/index.ts
@@ -1,0 +1,2 @@
+export { default as List } from './List';
+export { default as ListItem } from './ListItem';

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,4 +8,5 @@ export * from './Forms';
 export * from './Typography';
 export * from './Modals';
 export * from './Links';
+export * from './Lists';
 export * from './Spinners';


### PR DESCRIPTION
These components are variations of the `TableCellList` and `TableCellListItem`, with an "ordered" prop added to the List component to switch between a `<ul>` and `<ol>` element. This doesn't affect the appearance of the list, but it still important semantically.

Additionally, the borders between the list children have been moved to the parent List element, which provides just a bit more flexibility if we ever want to create multiple list components.

## Describe your changes
<!--
  In a few sentences, explain what your charges will do if merged. You can also
  use this space to ask any questions about your changes, highlight particular 
  issues, and provide any additional information about how to run and/or test 
  your code.
-->

## Types of changes
<!--
  What types of changes does your code introduce? Put an `x` in all the boxes
  that apply:
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
<!--
  Go over all the following points, and put an `x` in all the boxes that apply.
-->
- [x] I have run `eslint` on the code
- [x] I have added JSDoc for all of my code (where applicable)
- [x] I have added tests to cover my changes.

## Priority:
- [x] Normal <!-- New piece of functionality -->
- [ ] High <!-- Critical bug requiring urgent review -->

## Related Issues:
<!--
  Add the issue number in below that this PR is intended to address.

  Also mention any issues that this PR is related to, and if possible,
  provide more information regarding the relationship to the issues in
  question (i.e does the PR fix the issue, is it designed to fix another bug
  that is similar to the issue etc.)
-->
Fixes seas-computing/course-planner#407

<!--
  Attribution:
  PR Template adapted from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
