### PR TITLE
Add 'role' and 'aria-live' properties to ModalMessage

### DIFF
--- a/src/Modals/ModalMessage.tsx
+++ b/src/Modals/ModalMessage.tsx
@@ -14,7 +14,7 @@ export interface ModalMessageProps {
   /** The aria role of the message displayed */
   role?: string;
   /** The value of the aria-live property */
-  ariaLive?: ARIA_LIVE_VARIANT;
+  ariaLive?: string;
 }
 
 const StyledModalMessage = styled.span<ModalMessageProps>`

--- a/src/Modals/ModalMessage.tsx
+++ b/src/Modals/ModalMessage.tsx
@@ -12,9 +12,9 @@ export interface ModalMessageProps {
   /** Allows you to pass in a variant property from the VARIANT enum */
   variant: VARIANT;
   /** The aria role of the message displayed */
-  role: string;
+  role?: string;
   /** The value of the aria-live property */
-  ariaLive: string;
+  ariaLive?: ARIA_LIVE_VARIANT;
 }
 
 const StyledModalMessage = styled.span<ModalMessageProps>`

--- a/src/Modals/ModalMessage.tsx
+++ b/src/Modals/ModalMessage.tsx
@@ -1,8 +1,9 @@
+import { ARIA_LIVE_VARIANT } from 'const';
 import React, {
   FunctionComponent, ReactElement, useContext,
 } from 'react';
 import styled, { ThemeContext } from 'styled-components';
-import { ARIA_LIVE_VARIANT, fromTheme, VARIANT } from '../Theme';
+import { fromTheme, VARIANT } from '../Theme';
 
 export interface ModalMessageProps {
   /** The id of the modal message */

--- a/src/Modals/ModalMessage.tsx
+++ b/src/Modals/ModalMessage.tsx
@@ -1,8 +1,8 @@
-import { ARIA_LIVE_VARIANT } from 'const';
 import React, {
   FunctionComponent, ReactElement, useContext,
 } from 'react';
 import styled, { ThemeContext } from 'styled-components';
+import { ARIA_LIVE_VARIANT } from '../const';
 import { fromTheme, VARIANT } from '../Theme';
 
 export interface ModalMessageProps {

--- a/src/Modals/ModalMessage.tsx
+++ b/src/Modals/ModalMessage.tsx
@@ -11,6 +11,10 @@ export interface ModalMessageProps {
   children: string;
   /** Allows you to pass in a variant property from the VARIANT enum */
   variant: VARIANT;
+  /** The aria role of the message displayed */
+  role: string;
+  /** The value of the aria-live property */
+  ariaLive: string;
 }
 
 const StyledModalMessage = styled.span<ModalMessageProps>`
@@ -27,6 +31,8 @@ const ModalMessage: FunctionComponent<ModalMessageProps> = (props)
     id,
     children,
     variant,
+    role,
+    ariaLive,
   } = props;
   const theme = useContext(ThemeContext);
   return (
@@ -34,6 +40,8 @@ const ModalMessage: FunctionComponent<ModalMessageProps> = (props)
       id={id}
       variant={variant}
       theme={theme}
+      role={role}
+      aria-live={ariaLive}
     >
       {children}
     </StyledModalMessage>
@@ -42,6 +50,8 @@ const ModalMessage: FunctionComponent<ModalMessageProps> = (props)
 
 ModalMessage.defaultProps = {
   variant: VARIANT.BASE,
+  role: 'alert',
+  ariaLive: 'assertive',
 };
 
 export default ModalMessage;

--- a/src/Modals/ModalMessage.tsx
+++ b/src/Modals/ModalMessage.tsx
@@ -2,7 +2,7 @@ import React, {
   FunctionComponent, ReactElement, useContext,
 } from 'react';
 import styled, { ThemeContext } from 'styled-components';
-import { fromTheme, VARIANT } from '../Theme';
+import { ARIA_LIVE_VARIANT, fromTheme, VARIANT } from '../Theme';
 
 export interface ModalMessageProps {
   /** The id of the modal message */
@@ -14,7 +14,7 @@ export interface ModalMessageProps {
   /** The aria role of the message displayed */
   role?: string;
   /** The value of the aria-live property */
-  ariaLive?: string;
+  ariaLive?: ARIA_LIVE_VARIANT;
 }
 
 const StyledModalMessage = styled.span<ModalMessageProps>`
@@ -51,7 +51,7 @@ const ModalMessage: FunctionComponent<ModalMessageProps> = (props)
 ModalMessage.defaultProps = {
   variant: VARIANT.BASE,
   role: 'alert',
-  ariaLive: 'assertive',
+  ariaLive: ARIA_LIVE_VARIANT.ASSERTIVE,
 };
 
 export default ModalMessage;

--- a/src/Modals/ModalMessage.tsx
+++ b/src/Modals/ModalMessage.tsx
@@ -11,7 +11,11 @@ export interface ModalMessageProps {
   children: string;
   /** Allows you to pass in a variant property from the VARIANT enum */
   variant: VARIANT;
-  /** The aria role of the message displayed */
+  /** The aria role of the message displayed. A list of the different role
+   * values that should be used can be found in the w3 docs:
+   * https://www.w3.org/TR/wai-aria-1.1/#live_region_roles
+   * The default value role is 'alert.'
+   * */
   role?: string;
   /** The value of the aria-live property */
   ariaLive?: ARIA_LIVE_VARIANT;

--- a/src/Theme/utils.ts
+++ b/src/Theme/utils.ts
@@ -123,3 +123,9 @@ export enum TEXT_VARIANT {
   NEGATIVE = 'negative',
   BASE = 'base',
 }
+
+export enum ARIA_LIVE_VARIANT {
+  OFF = 'off',
+  ASSERTIVE = 'assertive',
+  POLITE = 'polite',
+}

--- a/src/Theme/utils.ts
+++ b/src/Theme/utils.ts
@@ -123,9 +123,3 @@ export enum TEXT_VARIANT {
   NEGATIVE = 'negative',
   BASE = 'base',
 }
-
-export enum ARIA_LIVE_VARIANT {
-  OFF = 'off',
-  ASSERTIVE = 'assertive',
-  POLITE = 'polite',
-}

--- a/src/const.ts
+++ b/src/const.ts
@@ -1,0 +1,21 @@
+/**
+ * These values specify the options for the aria-live attribute values that will
+ * indicate how assistive technologies should handle notifying the user of
+ * changes in content.
+ *
+ * ARIA_LIVE_VARIANT.OFF can be used to silence notifications for elements that
+ * that have a role of 'alert.'
+ *
+ * ARIA_LIVE_VARIANT.ASSERTIVE should be used for important notifications that
+ * require the user's attention such as notifications for error messages that
+ * occur during form submission.
+ *
+ * ARIA_LIVE_VARIANT.POLITE can be used for less important notifications. If the
+ * user is actively interacting with another part of the page, the screen reader
+ * will not interrupt the user to announce the notification.
+ */
+export enum ARIA_LIVE_VARIANT {
+  OFF = 'off',
+  ASSERTIVE = 'assertive',
+  POLITE = 'polite',
+}


### PR DESCRIPTION
In most cases, I would anticipate the `role` and `aria-live` values would be 'alert' and 'assertive, respectively. Since this may not always be the case, I added the props `role` and `ariaLive` so that the user can change the values but also added default values for both of these properties.

## Describe your changes
<!--
  In a few sentences, explain what your charges will do if merged. You can also
  use this space to ask any questions about your changes, highlight particular 
  issues, and provide any additional information about how to run and/or test 
  your code.
-->

## Types of changes
<!--
  What types of changes does your code introduce? Put an `x` in all the boxes
  that apply:
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
<!--
  Go over all the following points, and put an `x` in all the boxes that apply.
-->
- [x] I have run `eslint` on the code
- [x] I have added JSDoc for all of my code (where applicable)
- [x] I have added tests to cover my changes.

## Priority:
- [x] Normal <!-- New piece of functionality -->
- [ ] High <!-- Critical bug requiring urgent review -->

## Related Issues:
<!--
  Add the issue number in below that this PR is intended to address.

  Also mention any issues that this PR is related to, and if possible,
  provide more information regarding the relationship to the issues in
  question (i.e does the PR fix the issue, is it designed to fix another bug
  that is similar to the issue etc.)
-->
Fixes #374

<!--
  Attribution:
  PR Template adapted from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
