### PR TITLE
Add a placeholder prop to Combobox

### DIFF
--- a/examples/Forms/Combobox.md
+++ b/examples/Forms/Combobox.md
@@ -117,6 +117,7 @@ const [valueThree, setValueThree] = useState(null);
     hideError={true}
     options={options}
     label="Food"
+    placeholder="Choose a Food"
     currentValue={valueThree}
     onOptionSelected={({ selectedItem }) => {setValueThree(selectedItem)}}
   />

--- a/src/Forms/Combobox.tsx
+++ b/src/Forms/Combobox.tsx
@@ -100,6 +100,11 @@ interface ComboboxProps {
    * The list of items that should be selectable in the combobox
    */
   options: ComboboxOption[];
+  /**
+   * Temporary text that will be displayed in the input before the user types
+   * anything
+   */
+  placeholder?: string;
 }
 
 /**
@@ -215,6 +220,7 @@ const Combobox: FunctionComponent<ComboboxProps> = (
     labelPosition,
     onOptionSelected,
     options,
+    placeholder,
   }
 ): ReactElement => {
   /**
@@ -278,6 +284,7 @@ const Combobox: FunctionComponent<ComboboxProps> = (
       <InputWrapper {...getComboboxProps()}>
         <StyledTextInput
           {...getInputProps({ ref: forwardRef })}
+          placeholder={placeholder}
         />
         <ComboboxMenu isOpen={isOpen} {...getMenuProps({ refKey: 'ref' })}>
           {filteredOptions.length > 0
@@ -323,6 +330,7 @@ Combobox.defaultProps = {
   hideError: false,
   isLabelVisible: true,
   isRequired: false,
+  placeholder: '',
 };
 
 export default Combobox;


### PR DESCRIPTION
I neglected to add a pass-through placeholder to the Combobox, which we'll need because the search field in the Instructor Modal doesn't have a visible label. (Ironically this is fine for screen readers but we'll need a cue for sighted users that the box is used to add instructors.)

## Describe your changes
<!--
  In a few sentences, explain what your charges will do if merged. You can also
  use this space to ask any questions about your changes, highlight particular 
  issues, and provide any additional information about how to run and/or test 
  your code.
-->

## Types of changes
<!--
  What types of changes does your code introduce? Put an `x` in all the boxes
  that apply:
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
<!--
  Go over all the following points, and put an `x` in all the boxes that apply.
-->
- [x] I have run `eslint` on the code
- [x] I have added JSDoc for all of my code (where applicable)
- [x] I have added tests to cover my changes.

## Priority:
- [x] Normal <!-- New piece of functionality -->
- [ ] High <!-- Critical bug requiring urgent review -->

## Related Issues:
<!--
  Add the issue number in below that this PR is intended to address.

  Also mention any issues that this PR is related to, and if possible,
  provide more information regarding the relationship to the issues in
  question (i.e does the PR fix the issue, is it designed to fix another bug
  that is similar to the issue etc.)
-->
Fixes seas-computing/course-planner#411

<!--
  Attribution:
  PR Template adapted from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
