### PR TITLE
Size Popover to content

### DIFF
--- a/src/Popover/Popover.tsx
+++ b/src/Popover/Popover.tsx
@@ -81,6 +81,7 @@ const PopoverWrapper = styled.div<PopoverWrapperProps>`
   bottom: ${({ bottom }) => bottom};
   color: ${fromTheme('color', 'text', 'dark')};
   max-width: 10em;
+  width: max-content;
   z-index: 10;
   > div.mark-one__popover-heading {
     background-color: ${fromTheme('color', 'background', 'subtle')};


### PR DESCRIPTION
Just having a max-width was causing weird issues when I tried to add
longer text into the body of the popover in Course Planner. The fastest
fix I found was to also set a width equal to max-content, which makes it
use as much space as it actually needs, up to that 10em max-width.

## Describe your changes
<!--
  In a few sentences, explain what your charges will do if merged. You can also
  use this space to ask any questions about your changes, highlight particular 
  issues, and provide any additional information about how to run and/or test 
  your code.
-->

## Types of changes
<!--
  What types of changes does your code introduce? Put an `x` in all the boxes
  that apply:
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
<!--
  Go over all the following points, and put an `x` in all the boxes that apply.
-->
- [x] I have run `eslint` on the code
- [x] I have added JSDoc for all of my code (where applicable)
- [x] I have added tests to cover my changes.

## Priority:
- [x] Normal <!-- New piece of functionality -->
- [ ] High <!-- Critical bug requiring urgent review -->


<!--
  Attribution:
  PR Template adapted from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
