### PR TITLE
Set combo box button type

### DIFF
--- a/src/Forms/Combobox.tsx
+++ b/src/Forms/Combobox.tsx
@@ -126,7 +126,7 @@ const ComboboxWrapper = styled(StyledInputLabel).attrs({
 const ComboboxLabel = styled(StyledInputLabelText).attrs({
   as: 'label',
 })`
-  grid-area: l; 
+  grid-area: l;
 `;
 
 /**
@@ -304,6 +304,7 @@ const Combobox: FunctionComponent<ComboboxProps> = (
             )}
         </ComboboxMenu>
         <ComboboxButton
+          type="button"
           alt={`Show all options for ${label}`}
           {...getToggleButtonProps({ refKey: 'forwardRef' })}
         >


### PR DESCRIPTION
## Describe your changes
Added button type to combo box dropdown. This prevents the button from accidentally submitting the form. You can see a reproduction of this by pasting the below code into the docs [here](https://seas-computing.github.io/mark-one/#/Forms?id=combobox)

## Types of changes
<!--
  What types of changes does your code introduce? Put an `x` in all the boxes
  that apply:
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
<!--
  Go over all the following points, and put an `x` in all the boxes that apply.
-->
- [x] I have run `eslint` on the code
- [ ] I have added JSDoc for all of my code (where applicable)
- [ ] I have added tests to cover my changes.

## Priority:
- [x] Normal <!-- New piece of functionality -->
- [ ] High <!-- Critical bug requiring urgent review -->

## Related Issues:
<!--
  Add the issue number in below that this PR is intended to address.

  Also mention any issues that this PR is related to, and if possible,
  provide more information regarding the relationship to the issues in
  question (i.e does the PR fix the issue, is it designed to fix another bug
  that is similar to the issue etc.)
-->
Fixes #150

<!--
  Attribution:
  PR Template adapted from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
