### PR TITLE
Bugfix 153/footer should stick to the bottom of the page

### DIFF
--- a/src/Layout/Footer.tsx
+++ b/src/Layout/Footer.tsx
@@ -29,8 +29,8 @@ const Footer = styled.footer<FooterProps>`
   position: fixed;
   bottom: 0;
   height: 40px;
-  font-size: 0.9em;
-  font-weight: 400;
+  font-size: ${({ theme }) => `${theme.font.base.size}`};
+  font-weight: ${({ theme }) => `${theme.font.base.weight}`};
 `;
 
 Footer.defaultProps = {


### PR DESCRIPTION
## Describe your changes
 The footer component on course planner page did not have a fixed position causing it to move way up during  the page gets refreshed and also when the table size get small. To fix that, position added and solid white(light) background color added to make it visible and not blend with the table. 

## Types of changes
<!--
  What types of changes does your code introduce? Put an `x` in all the boxes
  that apply:
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
<!--
  Go over all the following points, and put an `x` in all the boxes that apply.
-->
- [X] I have run `eslint` on the code
- [ ] I have added JSDoc for all of my code (where applicable)
- [ ] I have added tests to cover my changes.

## Priority:
- [X] Normal <!-- New piece of functionality -->
- [ ] High <!-- Critical bug requiring urgent review -->

## Related Issues:
<!--
  Add the issue number in below that this PR is intended to address.

  Also mention any issues that this PR is related to, and if possible,
  provide more information regarding the relationship to the issues in
  question (i.e does the PR fix the issue, is it designed to fix another bug
  that is similar to the issue etc.)
-->
Fixes #153

<!--
  Attribution:
  PR Template adapted from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
