### PR TITLE
Allow for non-floating footer

### DIFF
--- a/examples/Layout/Footer.md
+++ b/examples/Layout/Footer.md
@@ -24,6 +24,19 @@ You can also pass in a custom `background` prop to replace the default transpare
 </Footer>
 ```
 
+The `position` prop can be used to control how the footer is positioned on the
+page. By default, the footer will be `sticky`, appearing `fixed` while
+scrolling the page, then `relative` when it reaches the bottom of the content.
+You can set it to always appear at the end of the content by setting position
+to `relative`."
+
+
+```jsx
+<Footer position="relative">
+  <div>Version 10.0</div>
+</Footer>
+```
+
 An unordered list can be provided to the `Footer`, and each list item will be spaced accordingly.
 ```jsx
 import { ExternalLink } from 'mark-one';

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@openfonts/open-sans_all": "^1.43.0",
         "@openfonts/roboto-mono_all": "^1.43.0",
         "@testing-library/react-hooks": "^7.0.2",
+        "csstype": "^3.1.3",
         "downshift": "^6.1.7",
         "polished": "^3.4.1",
         "react-transition-group": "^4.3.0"
@@ -855,6 +856,11 @@
         "@types/react": "*"
       }
     },
+    "node_modules/@types/react/node_modules/csstype": {
+      "version": "2.6.21",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.21.tgz",
+      "integrity": "sha512-Z1PhmomIfypOpoMjRQB70jfvy/wxT50qW08YXO5lMIJkrdq4yOTR+AW7FqutScmB9NkLwxo+jU+kZLbofZZq/w=="
+    },
     "node_modules/@types/sinon": {
       "version": "7.5.2",
       "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-7.5.2.tgz",
@@ -878,6 +884,12 @@
         "@types/react-native": "*",
         "csstype": "^2.2.0"
       }
+    },
+    "node_modules/@types/styled-components/node_modules/csstype": {
+      "version": "2.6.21",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.21.tgz",
+      "integrity": "sha512-Z1PhmomIfypOpoMjRQB70jfvy/wxT50qW08YXO5lMIJkrdq4yOTR+AW7FqutScmB9NkLwxo+jU+kZLbofZZq/w==",
+      "dev": true
     },
     "node_modules/@types/tapable": {
       "version": "1.0.6",
@@ -3475,9 +3487,9 @@
       "dev": true
     },
     "node_modules/csstype": {
-      "version": "2.6.13",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.13.tgz",
-      "integrity": "sha512-ul26pfSQTZW8dcOnD2iiJssfXw0gdNVX9IJDH/X3K5DGPfj+fUYe3kB+swUY6BF3oZDxaID3AJt+9/ojSAE05A=="
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "node_modules/cyclist": {
       "version": "1.0.1",
@@ -3874,6 +3886,11 @@
         "@babel/runtime": "^7.8.7",
         "csstype": "^2.6.7"
       }
+    },
+    "node_modules/dom-helpers/node_modules/csstype": {
+      "version": "2.6.21",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.21.tgz",
+      "integrity": "sha512-Z1PhmomIfypOpoMjRQB70jfvy/wxT50qW08YXO5lMIJkrdq4yOTR+AW7FqutScmB9NkLwxo+jU+kZLbofZZq/w=="
     },
     "node_modules/domain-browser": {
       "version": "1.2.0",
@@ -7468,6 +7485,12 @@
         "jss": "^10.3.0",
         "tiny-warning": "^1.0.2"
       }
+    },
+    "node_modules/jss/node_modules/csstype": {
+      "version": "2.6.21",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.21.tgz",
+      "integrity": "sha512-Z1PhmomIfypOpoMjRQB70jfvy/wxT50qW08YXO5lMIJkrdq4yOTR+AW7FqutScmB9NkLwxo+jU+kZLbofZZq/w==",
+      "dev": true
     },
     "node_modules/jsx-ast-utils": {
       "version": "2.4.1",
@@ -15326,6 +15349,13 @@
       "requires": {
         "@types/prop-types": "*",
         "csstype": "^2.2.0"
+      },
+      "dependencies": {
+        "csstype": {
+          "version": "2.6.21",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.21.tgz",
+          "integrity": "sha512-Z1PhmomIfypOpoMjRQB70jfvy/wxT50qW08YXO5lMIJkrdq4yOTR+AW7FqutScmB9NkLwxo+jU+kZLbofZZq/w=="
+        }
       }
     },
     "@types/react-dom": {
@@ -15405,6 +15435,14 @@
         "@types/react": "*",
         "@types/react-native": "*",
         "csstype": "^2.2.0"
+      },
+      "dependencies": {
+        "csstype": {
+          "version": "2.6.21",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.21.tgz",
+          "integrity": "sha512-Z1PhmomIfypOpoMjRQB70jfvy/wxT50qW08YXO5lMIJkrdq4yOTR+AW7FqutScmB9NkLwxo+jU+kZLbofZZq/w==",
+          "dev": true
+        }
       }
     },
     "@types/tapable": {
@@ -17680,9 +17718,9 @@
       }
     },
     "csstype": {
-      "version": "2.6.13",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.13.tgz",
-      "integrity": "sha512-ul26pfSQTZW8dcOnD2iiJssfXw0gdNVX9IJDH/X3K5DGPfj+fUYe3kB+swUY6BF3oZDxaID3AJt+9/ojSAE05A=="
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "cyclist": {
       "version": "1.0.1",
@@ -18024,6 +18062,13 @@
       "requires": {
         "@babel/runtime": "^7.8.7",
         "csstype": "^2.6.7"
+      },
+      "dependencies": {
+        "csstype": {
+          "version": "2.6.21",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.21.tgz",
+          "integrity": "sha512-Z1PhmomIfypOpoMjRQB70jfvy/wxT50qW08YXO5lMIJkrdq4yOTR+AW7FqutScmB9NkLwxo+jU+kZLbofZZq/w=="
+        }
       }
     },
     "domain-browser": {
@@ -20961,6 +21006,14 @@
         "csstype": "^2.6.5",
         "is-in-browser": "^1.1.3",
         "tiny-warning": "^1.0.2"
+      },
+      "dependencies": {
+        "csstype": {
+          "version": "2.6.21",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.21.tgz",
+          "integrity": "sha512-Z1PhmomIfypOpoMjRQB70jfvy/wxT50qW08YXO5lMIJkrdq4yOTR+AW7FqutScmB9NkLwxo+jU+kZLbofZZq/w==",
+          "dev": true
+        }
       }
     },
     "jss-plugin-camel-case": {

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "@openfonts/open-sans_all": "^1.43.0",
     "@openfonts/roboto-mono_all": "^1.43.0",
     "@testing-library/react-hooks": "^7.0.2",
+    "csstype": "^3.1.3",
     "downshift": "^6.1.7",
     "polished": "^3.4.1",
     "react-transition-group": "^4.3.0"

--- a/src/Layout/Footer.tsx
+++ b/src/Layout/Footer.tsx
@@ -28,7 +28,6 @@ const Footer = styled.footer<FooterProps>`
   width: 100%;
   position: fixed;
   bottom: 0;
-  height: 40px;
   font-size: ${({ theme }) => `${theme.font.base.size}`};
   font-weight: ${({ theme }) => `${theme.font.base.weight}`};
   ul {

--- a/src/Layout/Footer.tsx
+++ b/src/Layout/Footer.tsx
@@ -1,5 +1,6 @@
 import { ReactNode, ReactElement } from 'react';
 import styled, { withTheme } from 'styled-components';
+import CSS from 'csstype';
 
 export interface FooterProps {
   /**
@@ -14,6 +15,11 @@ export interface FooterProps {
    * @default space-between
    */
   justify?: string;
+  /**
+   * Pass in a custom value for position
+   * @default sticky
+   */
+  position?: CSS.Property.Position;
 }
 
 /**
@@ -26,7 +32,7 @@ const Footer = styled.footer<FooterProps>`
   justify-content: ${({ justify }) => justify};
   padding: ${({ theme }) => `${theme.ws.medium} ${theme.ws.small}`};
   width: 100%;
-  position: fixed;
+  position: ${({ position }) => position};
   bottom: 0;
   font-size: ${({ theme }) => `${theme.font.base.size}`};
   font-weight: ${({ theme }) => `${theme.font.base.weight}`};
@@ -45,6 +51,7 @@ const Footer = styled.footer<FooterProps>`
 Footer.defaultProps = {
   background: 'transparent',
   justify: 'space-between',
+  position: 'sticky',
 };
 
 declare type Footer = ReactElement<FooterProps>;

--- a/src/Layout/Footer.tsx
+++ b/src/Layout/Footer.tsx
@@ -14,7 +14,7 @@ export interface FooterProps {
    * Pass in a custom value for justify-content
    * @default space-between
    */
-  justify?: string;
+  justify?: CSS.Property.JustifyContent;
   /**
    * Pass in a custom value for position
    * @default sticky

--- a/src/Layout/Footer.tsx
+++ b/src/Layout/Footer.tsx
@@ -34,8 +34,8 @@ const Footer = styled.footer<FooterProps>`
   width: 100%;
   position: ${({ position }) => position};
   bottom: 0;
-  font-size: ${({ theme }) => `${theme.font.base.size}`};
-  font-weight: ${({ theme }) => `${theme.font.base.weight}`};
+  font-size: ${({ theme }) => `${theme.font.footer.size}`};
+  font-weight: ${({ theme }) => `${theme.font.footer.weight}`};
   ul {
     list-style: none;
     display: flex;

--- a/src/Theme/MarkOneTheme.ts
+++ b/src/Theme/MarkOneTheme.ts
@@ -112,6 +112,11 @@ const MarkOneTheme: DefaultTheme = {
       size: '0.7em',
       weight: WEIGHT.BOLD,
     },
+    footer: {
+      family: FONT.SANS,
+      size: '0.9em',
+      weight: WEIGHT.MEDIUM,
+    },
   },
   shadow: {
     xlight: '0 2px 4px rgba(0,0,0,0.24)',

--- a/src/Theme/ThemeTypes.ts
+++ b/src/Theme/ThemeTypes.ts
@@ -34,9 +34,10 @@ export type FontCategory = 'base' |
 'data' |
 'note' |
 'bold' |
-'title'|
+'title' |
 'heading' |
-'error';
+'error' |
+'footer';
 
 export type WhiteSpaceSize = 'zero' |
 'xsmall' |


### PR DESCRIPTION
## Describe your changes

This adds a `position` prop to the `<Footer>` component, which is passed through the the CSS property of same name to allow for customization of the Footer styling. It also changes the default from `fixed` to `sticky`, which means that it will "un-float" when the window scrolls to the end of the page content -- that should fix the issue we've sometimes seen with the footer covering up the bottom of the page.



## Types of changes
<!--
  What types of changes does your code introduce? Put an `x` in all the boxes
  that apply:
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
<!--
  Go over all the following points, and put an `x` in all the boxes that apply.
-->
- [x] I have run `eslint` on the code
- [x] I have added JSDoc for all of my code (where applicable)
- [ ] I have added tests to cover my changes.

## Priority:
- [x] Normal <!-- New piece of functionality -->
- [ ] High <!-- Critical bug requiring urgent review -->

## Related Issues:
<!--
  Add the issue number in below that this PR is intended to address.

  Also mention any issues that this PR is related to, and if possible,
  provide more information regarding the relationship to the issues in
  question (i.e does the PR fix the issue, is it designed to fix another bug
  that is similar to the issue etc.)
-->
Fixes #161 

<!--
  Attribution:
  PR Template adapted from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
