### PR TITLE
Release v0.6.0

### DIFF
--- a/examples/Forms/Form.md
+++ b/examples/Forms/Form.md
@@ -107,3 +107,43 @@ const [notesValue, setNotesValue] = useState('');
   </Button>
 </Form>
 ```
+
+A `Form` component may also have an `onSubmit` handler too. This can be used to
+handle the semantic submission of a form, like so:
+
+```jsx
+import {
+  TextInput,
+  Button,
+  POSITION,
+  VARIANT,
+} from 'mark-one';
+import { useState } from 'react';
+
+const [text, setText] = useState('');
+const [items, setItems] = useState(['Eggs', 'Milk']);
+
+const submitHandler = () => {
+  setItems((prev) => prev.concat(text));
+  setText('');
+}
+
+<Form
+  label="Grocery List"
+  submitHandler={submitHandler}
+>
+  <TextInput
+    name="add-item"
+    value={text}
+    labelPosition={POSITION.TOP}
+    label="Add Item"
+    onChange={(event) => {
+      setText(event.target.value);
+    }}
+  />
+  <ul>
+    {items.map((item, index) => (<li key={item+index}>{item}</li>))}
+  </ul>
+  <Button variant={VARIANT.PRIMARY}>Submit</Button>
+</Form>
+```

--- a/examples/Layout/Footer.md
+++ b/examples/Layout/Footer.md
@@ -23,3 +23,17 @@ You can also pass in a custom `background` prop to replace the default transpare
   <div>Version 10.0</div>
 </Footer>
 ```
+
+An unordered list can be provided to the `Footer`, and each list item will be spaced accordingly.
+```jsx
+import { ExternalLink } from 'mark-one';
+
+<Footer justify="center">
+  <ul>
+    <li><ExternalLink href="https://seas.harvard.edu/office-diversity-inclusion-and-belonging/about-us" rel="nofollow">Diversity Mission</ExternalLink></li>
+    <li><ExternalLink href="https://trademark.harvard.edu/pages/trademark-notice" rel="nofollow">Trademark Notice</ExternalLink></li>
+    <li><ExternalLink href="https://accessibility.huit.harvard.edu/digital-accessibility-policy" rel="nofollow">Accessibility Policy</ExternalLink></li>
+    <li><ExternalLink href="https://seas.harvard.edu/privacy-policy" rel="nofollow">Privacy Policy</ExternalLink></li>
+  </ul>
+</Footer>
+```

--- a/examples/Layout/Footer.md
+++ b/examples/Layout/Footer.md
@@ -24,6 +24,19 @@ You can also pass in a custom `background` prop to replace the default transpare
 </Footer>
 ```
 
+The `position` prop can be used to control how the footer is positioned on the
+page. By default, the footer will be `sticky`, appearing `fixed` while
+scrolling the page, then `relative` when it reaches the bottom of the content.
+You can set it to always appear at the end of the content by setting position
+to `relative`."
+
+
+```jsx
+<Footer position="relative">
+  <div>Version 10.0</div>
+</Footer>
+```
+
 An unordered list can be provided to the `Footer`, and each list item will be spaced accordingly.
 ```jsx
 import { ExternalLink } from 'mark-one';

--- a/examples/Layout/Footer.md
+++ b/examples/Layout/Footer.md
@@ -1,0 +1,25 @@
+The Footer uses flexbox for positioning, and accepts a `justify` prop that controls the layout. The default value is `space-between`, which works well for multiple items:
+
+```jsx
+<Footer>
+  <div>Privacy Policy</div>
+  <div>Contact Us</div>
+  <div>Terms of Service</div>
+</Footer>
+```
+
+A value of `center` be used to position content around the center. (See [MDN's docs](https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content) for all supported values).
+
+```jsx
+<Footer justify="center">
+  <div>Version 10.0</div>
+</Footer>
+```
+
+You can also pass in a custom `background` prop to replace the default transparent background.
+
+```jsx
+<Footer justify="center" background="#eafeaf">
+  <div>Version 10.0</div>
+</Footer>
+```

--- a/examples/Modals/Modal.md
+++ b/examples/Modals/Modal.md
@@ -93,7 +93,7 @@ const switchModal = (isOpen) => {
           forwardRef={inputRef}
           label="Enter text:"
           value={formValue}
-          changeHandler={(evt) => {
+          onChange={(evt) => {
             setFormValue(evt.target.value);
           }}
         />

--- a/examples/Tables/Table.md
+++ b/examples/Tables/Table.md
@@ -202,6 +202,45 @@ import {
   </TableBody>
 </Table>
 ```
+The following example of the `Table` component is  where `isSticky` prop is set to make the TableHead position sticky.  In this case, when the page is scrolled, the TableHead will stick and the TableHead position defaults to `isSticky` property.
+
+```jsx
+import {
+  ALIGN,
+  Table,
+  TableCell,
+  TableBody,
+  TableRow,
+  TableHeadingCell,
+  TableHead,
+} from 'mark-one';
+
+import styled from 'styled-components';
+const TableWrapper = styled.div`
+  overflow: scroll;
+  height:20rem;
+`;
+ <TableWrapper>
+<Table>
+  <TableHead isSticky>
+    <TableRow>
+      <TableHeadingCell scope={'col'}>First Row</TableHeadingCell>
+      <TableHeadingCell scope={'col'}>Second Row</TableHeadingCell>
+      <TableHeadingCell scope={'col'}>Last Row</TableHeadingCell>
+    </TableRow>
+  </TableHead>
+  <TableBody isScrollable={true}>
+    {Array.from({length: 126}, (_, i) => (
+    <TableRow isStriped= {i%2===0}>
+      <TableCell>{i}</TableCell>
+      <TableCell>{i}</TableCell>
+      <TableCell>{i}</TableCell>
+    </TableRow>)
+    )}
+  </TableBody>
+</Table>
+</TableWrapper>
+```
 
 ### More Complex Layouts
 
@@ -324,4 +363,3 @@ import {
   </TableBody>
 </Table>
 ```
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mark-one",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "mark-one",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^1.2.26",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5622,6 +5622,7 @@
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
       "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
       "dev": true,
+      "hasInstallScript": true,
       "optional": true,
       "os": [
         "darwin"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mark-one",
-  "version": "0.5.13",
+  "version": "0.5.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "mark-one",
-      "version": "0.5.13",
+      "version": "0.5.14",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^1.2.26",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mark-one",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "mark-one",
-      "version": "0.5.6",
+      "version": "0.5.7",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^1.2.26",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mark-one",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "mark-one",
-      "version": "0.5.4",
+      "version": "0.5.5",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^1.2.26",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@openfonts/open-sans_all": "^1.43.0",
         "@openfonts/roboto-mono_all": "^1.43.0",
         "@testing-library/react-hooks": "^7.0.2",
+        "csstype": "^3.1.3",
         "downshift": "^6.1.7",
         "polished": "^3.4.1",
         "react-transition-group": "^4.3.0"
@@ -855,6 +856,11 @@
         "@types/react": "*"
       }
     },
+    "node_modules/@types/react/node_modules/csstype": {
+      "version": "2.6.21",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.21.tgz",
+      "integrity": "sha512-Z1PhmomIfypOpoMjRQB70jfvy/wxT50qW08YXO5lMIJkrdq4yOTR+AW7FqutScmB9NkLwxo+jU+kZLbofZZq/w=="
+    },
     "node_modules/@types/sinon": {
       "version": "7.5.2",
       "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-7.5.2.tgz",
@@ -878,6 +884,12 @@
         "@types/react-native": "*",
         "csstype": "^2.2.0"
       }
+    },
+    "node_modules/@types/styled-components/node_modules/csstype": {
+      "version": "2.6.21",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.21.tgz",
+      "integrity": "sha512-Z1PhmomIfypOpoMjRQB70jfvy/wxT50qW08YXO5lMIJkrdq4yOTR+AW7FqutScmB9NkLwxo+jU+kZLbofZZq/w==",
+      "dev": true
     },
     "node_modules/@types/tapable": {
       "version": "1.0.6",
@@ -3475,9 +3487,9 @@
       "dev": true
     },
     "node_modules/csstype": {
-      "version": "2.6.13",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.13.tgz",
-      "integrity": "sha512-ul26pfSQTZW8dcOnD2iiJssfXw0gdNVX9IJDH/X3K5DGPfj+fUYe3kB+swUY6BF3oZDxaID3AJt+9/ojSAE05A=="
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "node_modules/cyclist": {
       "version": "1.0.1",
@@ -3874,6 +3886,11 @@
         "@babel/runtime": "^7.8.7",
         "csstype": "^2.6.7"
       }
+    },
+    "node_modules/dom-helpers/node_modules/csstype": {
+      "version": "2.6.21",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.21.tgz",
+      "integrity": "sha512-Z1PhmomIfypOpoMjRQB70jfvy/wxT50qW08YXO5lMIJkrdq4yOTR+AW7FqutScmB9NkLwxo+jU+kZLbofZZq/w=="
     },
     "node_modules/domain-browser": {
       "version": "1.2.0",
@@ -7468,6 +7485,12 @@
         "jss": "^10.3.0",
         "tiny-warning": "^1.0.2"
       }
+    },
+    "node_modules/jss/node_modules/csstype": {
+      "version": "2.6.21",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.21.tgz",
+      "integrity": "sha512-Z1PhmomIfypOpoMjRQB70jfvy/wxT50qW08YXO5lMIJkrdq4yOTR+AW7FqutScmB9NkLwxo+jU+kZLbofZZq/w==",
+      "dev": true
     },
     "node_modules/jsx-ast-utils": {
       "version": "2.4.1",
@@ -15326,6 +15349,13 @@
       "requires": {
         "@types/prop-types": "*",
         "csstype": "^2.2.0"
+      },
+      "dependencies": {
+        "csstype": {
+          "version": "2.6.21",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.21.tgz",
+          "integrity": "sha512-Z1PhmomIfypOpoMjRQB70jfvy/wxT50qW08YXO5lMIJkrdq4yOTR+AW7FqutScmB9NkLwxo+jU+kZLbofZZq/w=="
+        }
       }
     },
     "@types/react-dom": {
@@ -15405,6 +15435,14 @@
         "@types/react": "*",
         "@types/react-native": "*",
         "csstype": "^2.2.0"
+      },
+      "dependencies": {
+        "csstype": {
+          "version": "2.6.21",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.21.tgz",
+          "integrity": "sha512-Z1PhmomIfypOpoMjRQB70jfvy/wxT50qW08YXO5lMIJkrdq4yOTR+AW7FqutScmB9NkLwxo+jU+kZLbofZZq/w==",
+          "dev": true
+        }
       }
     },
     "@types/tapable": {
@@ -17680,9 +17718,9 @@
       }
     },
     "csstype": {
-      "version": "2.6.13",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.13.tgz",
-      "integrity": "sha512-ul26pfSQTZW8dcOnD2iiJssfXw0gdNVX9IJDH/X3K5DGPfj+fUYe3kB+swUY6BF3oZDxaID3AJt+9/ojSAE05A=="
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "cyclist": {
       "version": "1.0.1",
@@ -18024,6 +18062,13 @@
       "requires": {
         "@babel/runtime": "^7.8.7",
         "csstype": "^2.6.7"
+      },
+      "dependencies": {
+        "csstype": {
+          "version": "2.6.21",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.21.tgz",
+          "integrity": "sha512-Z1PhmomIfypOpoMjRQB70jfvy/wxT50qW08YXO5lMIJkrdq4yOTR+AW7FqutScmB9NkLwxo+jU+kZLbofZZq/w=="
+        }
       }
     },
     "domain-browser": {
@@ -20961,6 +21006,14 @@
         "csstype": "^2.6.5",
         "is-in-browser": "^1.1.3",
         "tiny-warning": "^1.0.2"
+      },
+      "dependencies": {
+        "csstype": {
+          "version": "2.6.21",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.21.tgz",
+          "integrity": "sha512-Z1PhmomIfypOpoMjRQB70jfvy/wxT50qW08YXO5lMIJkrdq4yOTR+AW7FqutScmB9NkLwxo+jU+kZLbofZZq/w==",
+          "dev": true
+        }
       }
     },
     "jss-plugin-camel-case": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mark-one",
-  "version": "0.5.11",
+  "version": "0.5.12",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "mark-one",
-      "version": "0.5.11",
+      "version": "0.5.12",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^1.2.26",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mark-one",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "mark-one",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^1.2.26",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mark-one",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "mark-one",
-      "version": "0.5.5",
+      "version": "0.5.6",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^1.2.26",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mark-one",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "mark-one",
-      "version": "0.5.2",
+      "version": "0.5.3",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^1.2.26",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mark-one",
-  "version": "0.5.10",
+  "version": "0.5.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "mark-one",
-      "version": "0.5.10",
+      "version": "0.5.11",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^1.2.26",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mark-one",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "mark-one",
-      "version": "0.5.3",
+      "version": "0.5.4",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^1.2.26",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mark-one",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "mark-one",
-      "version": "0.5.7",
+      "version": "0.5.8",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^1.2.26",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mark-one",
-  "version": "0.5.8",
+  "version": "0.5.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "mark-one",
-      "version": "0.5.8",
+      "version": "0.5.9",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^1.2.26",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mark-one",
-  "version": "0.5.12",
+  "version": "0.5.13",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "mark-one",
-      "version": "0.5.12",
+      "version": "0.5.13",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^1.2.26",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mark-one",
-  "version": "0.5.9",
+  "version": "0.5.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "mark-one",
-      "version": "0.5.9",
+      "version": "0.5.10",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^1.2.26",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mark-one",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "A UI component library for building React Apps",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mark-one",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "description": "A UI component library for building React Apps",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mark-one",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "A UI component library for building React Apps",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mark-one",
-  "version": "0.5.8",
+  "version": "0.5.9",
   "description": "A UI component library for building React Apps",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mark-one",
-  "version": "0.5.9",
+  "version": "0.5.10",
   "description": "A UI component library for building React Apps",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mark-one",
-  "version": "0.5.11",
+  "version": "0.5.12",
   "description": "A UI component library for building React Apps",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mark-one",
-  "version": "0.5.12",
+  "version": "0.5.13",
   "description": "A UI component library for building React Apps",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mark-one",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "A UI component library for building React Apps",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mark-one",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "description": "A UI component library for building React Apps",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "@openfonts/open-sans_all": "^1.43.0",
     "@openfonts/roboto-mono_all": "^1.43.0",
     "@testing-library/react-hooks": "^7.0.2",
+    "csstype": "^3.1.3",
     "downshift": "^6.1.7",
     "polished": "^3.4.1",
     "react-transition-group": "^4.3.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mark-one",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "A UI component library for building React Apps",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mark-one",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "description": "A UI component library for building React Apps",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mark-one",
-  "version": "0.5.10",
+  "version": "0.5.11",
   "description": "A UI component library for building React Apps",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mark-one",
-  "version": "0.5.13",
+  "version": "0.5.14",
   "description": "A UI component library for building React Apps",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mark-one",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "A UI component library for building React Apps",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/Alerts/MessageContext.tsx
+++ b/src/Alerts/MessageContext.tsx
@@ -1,0 +1,102 @@
+import { createContext, Dispatch, Reducer } from 'react';
+
+/**
+ * A function that passes down a message to the queue
+ */
+export type DispatchMessage = Dispatch<MessageReducerAction>;
+
+/**
+ * Global message provider
+ */
+export const MessageContext = createContext<DispatchMessage>(null);
+
+/**
+ * Possible types of message to display to the user
+ */
+export enum MESSAGE_TYPE {
+  ERROR = 'ERROR',
+  SUCCESS = 'SUCCESS',
+  INFO = 'INFO',
+}
+
+/**
+ * Possible actions to take on the message queue
+ */
+export enum MESSAGE_ACTION {
+  PUSH = 'PUSH',
+  CLEAR = 'CLEAR',
+}
+
+/**
+ * Used for displaying messages on the client
+ */
+export class AppMessage {
+  public readonly variant: MESSAGE_TYPE;
+
+  public readonly text: string;
+
+  /**
+   * Create a new application message. By default, sets the message priority to
+   * "info", but alternativae values can be passed in as the second parameter.
+   */
+  public constructor(
+    message: string,
+    variant: MESSAGE_TYPE = MESSAGE_TYPE.INFO
+  ) {
+    this.variant = variant;
+    this.text = message;
+  }
+}
+
+/**
+ * Defines the state of the message reducer
+ */
+export interface MessageReducerState {
+  queue: AppMessage[];
+  currentMessage: AppMessage;
+}
+
+/**
+ * Defines that kinds of actions that can be accepted by the reducer
+ */
+export interface MessageReducerAction {
+  type: MESSAGE_ACTION;
+  message?: AppMessage;
+}
+
+/**
+ * handles queueing logic for the top-level app component
+ */
+export const messageReducer:
+Reducer<MessageReducerState, MessageReducerAction> = (
+  state,
+  action
+): MessageReducerState => {
+  const { currentMessage, queue } = state;
+  switch (action.type) {
+    case (MESSAGE_ACTION.PUSH): {
+      if (!currentMessage) {
+        return ({
+          ...state,
+          currentMessage: action.message,
+        });
+      }
+      const newQueue = [...queue, action.message];
+      return {
+        ...state,
+        queue: newQueue,
+      };
+    }
+    case (MESSAGE_ACTION.CLEAR): {
+      const nextQueue = [...queue];
+      const nextMessage = nextQueue.shift();
+      return {
+        queue: nextQueue,
+        currentMessage: nextMessage,
+      };
+    }
+    default:
+      return state;
+  }
+};
+export default MessageContext;

--- a/src/Alerts/index.ts
+++ b/src/Alerts/index.ts
@@ -1,1 +1,2 @@
 export { default as GlobalMessage } from './GlobalMessage';
+export { default as MessageContext } from './MessageContext';

--- a/src/Buttons/Button.tsx
+++ b/src/Buttons/Button.tsx
@@ -18,7 +18,7 @@ export interface ButtonProps extends MarkOneProps<HTMLButtonElement> {
   /** Text or components to be displayed on the button */
   children?: ReactNode;
   /** Function to call on click event */
-  onClick: MouseEventHandler;
+  onClick: MouseEventHandler | (() => Promise<void>);
   /** If true, button won't fire */
   disabled?: boolean;
   /** Allows you to pass in a variant property from the VARIANT enum */

--- a/src/Forms/Combobox.tsx
+++ b/src/Forms/Combobox.tsx
@@ -126,7 +126,7 @@ const ComboboxWrapper = styled(StyledInputLabel).attrs({
 const ComboboxLabel = styled(StyledInputLabelText).attrs({
   as: 'label',
 })`
-  grid-area: l; 
+  grid-area: l;
 `;
 
 /**
@@ -304,6 +304,7 @@ const Combobox: FunctionComponent<ComboboxProps> = (
             )}
         </ComboboxMenu>
         <ComboboxButton
+          type="button"
           alt={`Show all options for ${label}`}
           {...getToggleButtonProps({ refKey: 'forwardRef' })}
         >

--- a/src/Forms/Form.tsx
+++ b/src/Forms/Form.tsx
@@ -1,4 +1,8 @@
-import { FunctionComponent } from 'react';
+import {
+  FunctionComponent,
+  FormEventHandler,
+  FormEvent,
+} from 'react';
 import styled from 'styled-components';
 import { fromTheme } from '../Theme';
 
@@ -7,12 +11,18 @@ export interface FormProps {
   id?: string;
   /** A label that specifies the purpose of the form */
   label: string;
+  /** Handler attached to the onSubmit handler */
+  submitHandler?: FormEventHandler<HTMLFormElement>
 }
 
 const Form: FunctionComponent<FormProps> = styled.form.attrs(
   (props: FormProps) => ({
     id: props.id,
     'aria-label': props.label,
+    onSubmit: (e: FormEvent<HTMLFormElement>) => {
+      e.preventDefault();
+      props.submitHandler(e);
+    },
   })
 )`
   & > * {

--- a/src/Forms/MultiLineTextInput.tsx
+++ b/src/Forms/MultiLineTextInput.tsx
@@ -37,7 +37,7 @@ export interface MultiLineTextInputProps {
   placeholder: string;
 }
 
-export const StyledTextArea = styled.textarea<MultiLineTextInputProps>`
+export const StyledTextArea = styled.textarea<Omit<MultiLineTextInputProps, 'label'>>`
   border: ${fromTheme('border', 'hairline')};
   width: 100%;
   padding: ${fromTheme('ws', 'xsmall')};
@@ -87,7 +87,6 @@ ReactElement => {
         aria-disabled={isDisabled}
         ref={forwardRef}
         name={name}
-        label={label}
         placeholder={placeholder}
       />
       {errorMessage && (

--- a/src/Forms/__tests__/Form.test.tsx
+++ b/src/Forms/__tests__/Form.test.tsx
@@ -1,40 +1,31 @@
-import { Button } from 'Buttons';
-import { Form, TextInput } from 'Forms';
+import { Form } from 'Forms';
+import { strictEqual } from 'assert';
 import React from 'react';
+import { SinonStub, stub } from 'sinon';
 import {
+  fireEvent,
   render,
-  BoundFunction,
-  GetByRole,
 } from 'test-utils';
-import { VARIANT } from 'Theme';
 
 describe('Form', function () {
-  let getByRole: BoundFunction<GetByRole>;
-  const formLabel = 'New Student Registration Form';
+  let form: HTMLFormElement;
+  let submitStub: SinonStub;
+
   beforeEach(function () {
-    ({ getByRole } = render(
+    submitStub = stub();
+    const renderResult = render(
       <Form
         id="testForm"
-        label={formLabel}
-      >
-        <TextInput
-          id="testSemester"
-          name="semester"
-          value="Spring"
-          errorMessage="Error: Please enter a valid ID"
-          label="semester"
-          onChange={() => {}}
-        />
-        <Button
-          onClick={() => {}}
-          variant={VARIANT.BASE}
-        >
-          Submit
-        </Button>
-      </Form>
-    ));
+        label="Test Form"
+        submitHandler={submitStub}
+      />
+    );
+    form = renderResult.getByRole('form') as HTMLFormElement;
   });
-  it('renders', function () {
-    getByRole('form');
+  describe('submitHandler', function () {
+    it('is called when the form is submitted', function () {
+      fireEvent.submit(form);
+      strictEqual(submitStub.called, true);
+    });
   });
 });

--- a/src/Layout/Footer.tsx
+++ b/src/Layout/Footer.tsx
@@ -1,5 +1,6 @@
 import { ReactNode, ReactElement } from 'react';
 import styled, { withTheme } from 'styled-components';
+import CSS from 'csstype';
 
 export interface FooterProps {
   /**
@@ -13,7 +14,12 @@ export interface FooterProps {
    * Pass in a custom value for justify-content
    * @default space-between
    */
-  justify?: string;
+  justify?: CSS.Property.JustifyContent;
+  /**
+   * Pass in a custom value for position
+   * @default sticky
+   */
+  position?: CSS.Property.Position;
 }
 
 /**
@@ -26,11 +32,10 @@ const Footer = styled.footer<FooterProps>`
   justify-content: ${({ justify }) => justify};
   padding: ${({ theme }) => `${theme.ws.medium} ${theme.ws.small}`};
   width: 100%;
-  position: fixed;
+  position: ${({ position }) => position};
   bottom: 0;
-  height: 40px;
-  font-size: ${({ theme }) => `${theme.font.base.size}`};
-  font-weight: ${({ theme }) => `${theme.font.base.weight}`};
+  font-size: ${({ theme }) => `${theme.font.footer.size}`};
+  font-weight: ${({ theme }) => `${theme.font.footer.weight}`};
   ul {
     list-style: none;
     display: flex;
@@ -46,6 +51,7 @@ const Footer = styled.footer<FooterProps>`
 Footer.defaultProps = {
   background: 'transparent',
   justify: 'space-between',
+  position: 'sticky',
 };
 
 declare type Footer = ReactElement<FooterProps>;

--- a/src/Layout/Footer.tsx
+++ b/src/Layout/Footer.tsx
@@ -31,6 +31,16 @@ const Footer = styled.footer<FooterProps>`
   height: 40px;
   font-size: ${({ theme }) => `${theme.font.base.size}`};
   font-weight: ${({ theme }) => `${theme.font.base.weight}`};
+  ul {
+    list-style: none;
+    display: flex;
+    li {
+      padding: 0 0.5rem;
+      border-right: 1px solid black;
+      &:last-of-type {
+        border: 0px;
+      }
+  };
 `;
 
 Footer.defaultProps = {

--- a/src/Layout/Footer.tsx
+++ b/src/Layout/Footer.tsx
@@ -1,0 +1,38 @@
+import { ReactNode, ReactElement } from 'react';
+import styled, { withTheme } from 'styled-components';
+
+export interface FooterProps {
+  /**
+   * Allows for applying a custom background color
+   * @default "transparent"
+   */
+  background?: string;
+  /** Footer contents */
+  children?: ReactNode;
+  /**
+   * Pass in a custom value for justify-content
+   * @default space-between
+   */
+  justify?: string;
+}
+
+/**
+ * A full-width footer to be displayed at the bottom of the page
+ */
+const Footer = styled.main<FooterProps>`
+  align-items: baseline;
+  background-color: ${({ background }) => background};
+  display: flex;
+  justify-content: ${({ justify }) => justify};
+  padding: ${({ theme }) => `${theme.ws.medium} ${theme.ws.small}`};
+  width: 100%;
+`;
+
+Footer.defaultProps = {
+  background: 'transparent',
+  justify: 'space-between',
+};
+
+declare type Footer = ReactElement<FooterProps>;
+
+export default withTheme(Footer);

--- a/src/Layout/Footer.tsx
+++ b/src/Layout/Footer.tsx
@@ -21,11 +21,16 @@ export interface FooterProps {
  */
 const Footer = styled.footer<FooterProps>`
   align-items: baseline;
-  background-color: ${({ background }) => background};
+  background: ${({ theme }) => theme.color.background.light};
   display: flex;
   justify-content: ${({ justify }) => justify};
   padding: ${({ theme }) => `${theme.ws.medium} ${theme.ws.small}`};
   width: 100%;
+  position: fixed;
+  bottom: 0;
+  height: 40px;
+  font-size: ${({ theme }) => `${theme.font.base.size}`};
+  font-weight: ${({ theme }) => `${theme.font.base.weight}`};
 `;
 
 Footer.defaultProps = {

--- a/src/Layout/Footer.tsx
+++ b/src/Layout/Footer.tsx
@@ -19,7 +19,7 @@ export interface FooterProps {
 /**
  * A full-width footer to be displayed at the bottom of the page
  */
-const Footer = styled.main<FooterProps>`
+const Footer = styled.footer<FooterProps>`
   align-items: baseline;
   background-color: ${({ background }) => background};
   display: flex;

--- a/src/Layout/PageBody.tsx
+++ b/src/Layout/PageBody.tsx
@@ -5,10 +5,13 @@ import { fromTheme } from '../Theme';
 export interface PageBodyProps {
   /** Page contents */
   children?: ReactNode;
+  /** Padding of the page body */
+  padding?: string;
 }
 
 const PageBody = styled.main<PageBodyProps>`
   margin: ${fromTheme('ws', 'small')};
+  padding: ${({ padding, theme }): string => (padding || `0 0 ${theme.ws.xlarge}`)};
 `;
 
 declare type PageBody = ReactElement<PageBodyProps>;

--- a/src/Layout/__tests__/Footer.test.tsx
+++ b/src/Layout/__tests__/Footer.test.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { strictEqual } from 'assert';
+import { render } from 'test-utils';
+import Footer from '../Footer';
+
+describe('Footer', function () {
+  const footerText = 'Version 10.0';
+  it('renders any content provided', function () {
+    const { childElementCount, firstChild, textContent } = render(
+      <Footer>
+        <span>{footerText}</span>
+      </Footer>
+    ).getByRole('main');
+
+    strictEqual(childElementCount, 1);
+    strictEqual(textContent, footerText);
+    strictEqual(firstChild.nodeName, 'SPAN');
+  });
+});

--- a/src/Layout/__tests__/Footer.test.tsx
+++ b/src/Layout/__tests__/Footer.test.tsx
@@ -10,7 +10,7 @@ describe('Footer', function () {
       <Footer>
         <span>{footerText}</span>
       </Footer>
-    ).getByRole('main');
+    ).getByRole('contentinfo');
 
     strictEqual(childElementCount, 1);
     strictEqual(textContent, footerText);

--- a/src/Layout/index.ts
+++ b/src/Layout/index.ts
@@ -1,3 +1,4 @@
 export { default as Header } from './Header';
 export { default as Logo } from './Logo';
 export { default as PageBody } from './PageBody';
+export { default as Footer } from './Footer';

--- a/src/Tables/Table.tsx
+++ b/src/Tables/Table.tsx
@@ -13,9 +13,41 @@ export interface TableProps {
 }
 
 const StyledTable = styled.table<TableProps>`
-    border-collapse: collapse;
-    padding: ${({ theme }) => (theme.ws.xsmall + ' ' + theme.ws.small)};
+    border-collapse: separate;
+    border-spacing: 0;
     width: 100%;
+    & thead {
+      & th {
+        border: none;
+      }
+      & tr > th {
+        border-top: ${({ theme }): string => theme.border.light};
+        border-right: ${({ theme }): string => theme.border.light};
+      }
+      & tr > th:first-of-type {
+        border-left: ${({ theme }): string => theme.border.light};
+      }
+      & tr > th[rowspan]:not([rowspan='1']) {
+        border-bottom: ${({ theme }): string => theme.border.light};
+      }
+      & tr:last-of-type > th {
+        border-bottom: ${({ theme }): string => theme.border.light};
+      }
+    }
+    & tbody {
+      & tr > td, th {
+        border: none;
+      }
+      & tr > *:first-child {
+        border-left: ${({ theme }): string => theme.border.light};
+      }
+      & tr > :is(td,th) {
+        border-right: ${({ theme }): string => theme.border.light};
+      }
+      & tr:last-of-type > :is(td,th) {
+        border-bottom: ${({ theme }): string => theme.border.light};
+      }
+    }
 `;
 
 /**

--- a/src/Tables/TableHead.tsx
+++ b/src/Tables/TableHead.tsx
@@ -4,12 +4,19 @@ import { fromTheme } from '../Theme';
 import TableRow from './TableRow';
 
 export interface TableHeadProps {
+  /** Implements TableHeadingCell to stick while the tablebody is scrolled  */
+  isSticky?: boolean;
   /** Our TableRow functional component serves as the children for TableHead */
   children: TableRow | TableRow[];
 }
 
 const StyledTableHead = styled.thead<TableHeadProps>`
   background-color: ${fromTheme('color', 'background', 'medium')};
+  ${({ isSticky }) => (isSticky && `
+    position: sticky;
+    top: 0;
+    z-index: 0;
+  `)}
 `;
 
 /**

--- a/src/Theme/MarkOneTheme.ts
+++ b/src/Theme/MarkOneTheme.ts
@@ -112,6 +112,11 @@ const MarkOneTheme: DefaultTheme = {
       size: '0.7em',
       weight: WEIGHT.BOLD,
     },
+    footer: {
+      family: FONT.SANS,
+      size: '0.9em',
+      weight: WEIGHT.MEDIUM,
+    },
   },
   shadow: {
     xlight: '0 2px 4px rgba(0,0,0,0.24)',

--- a/src/Theme/ThemeTypes.ts
+++ b/src/Theme/ThemeTypes.ts
@@ -34,9 +34,10 @@ export type FontCategory = 'base' |
 'data' |
 'note' |
 'bold' |
-'title'|
+'title' |
 'heading' |
-'error';
+'error' |
+'footer';
 
 export type WhiteSpaceSize = 'zero' |
 'xsmall' |

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+import './styled';
+
 export * from './Buttons';
 export * from './Layout';
 export * from './Tabs';

--- a/src/styled.ts
+++ b/src/styled.ts
@@ -14,7 +14,7 @@ import {
 declare module 'styled-components' {
   export interface DefaultTheme {
     color: {
-      background:{
+      background: {
         [K in VARIANT | keyof ColorRange]:
         K extends VARIANT
           ? ColorRange
@@ -41,3 +41,5 @@ declare module 'styled-components' {
     };
   }
 }
+
+export {};


### PR DESCRIPTION
## New Features

- Create `Footer` component, which will be used to add policy links as well as the app version number (part of seas-computing/course-planner#618)
- Add `isSticky` property to `TableHead` component such that when its value is true, the table head sticks when scrolling (closes seas-computing/course-planner#345)
- Update`Footer` to account for unordered lists for links (closes https://github.huit.harvard.edu/SEAS/react-boilerplate/issues/11)
- Move `MessageContext` into `Mark One` (closes https://github.huit.harvard.edu/SEAS/react-boilerplate/issues/1)
- Add a `position` prop to the `Footer` to allow for further customization of footer styling (closes seas-computing/mark-one#161)
- Include a `submitHandler` prop for the `Form`, which bakes in an `event.preventDefault()` call (part of 

## Bug Fixes
- Fix `Footer` component to use the footer tag instead of the main tag (part of seas-computing/course-planner#618)
- Update `Combobox` button such that it does not submit the form it's within when it is selected (closes seas-computing/mark-one#150)
- Revise `Footer` such that it sticks to the bottom of the page rather than being in the middle of the page (closes seas-computing/mark-one#153)
- Remove `label` property from `StyledTextArea`, as `textarea` is non-labellable (part of seas-computing/course-planner#638)
- Fix export of theme type so that the declarations carry over to the final output (closes seas-computing/mark-one#162)
- Correct `Modal` markdown example's `TextInput` to use `onChange` instead of `changeHandler (closes seas-computing/mark-one#167)
