### PR TITLE
Add MenuFlex and Paragraph components

### DIFF
--- a/examples/Layout/MenuFlex.md
+++ b/examples/Layout/MenuFlex.md
@@ -1,0 +1,30 @@
+A flex container to display a menu of items:
+
+```jsx
+import { useState } from 'react';
+import { Checkbox, TextInput, POSITION } from 'mark-one';
+
+const [checkboxValue, setCheckboxValue] = useState(false);
+const [textValue, setTextValue] = useState('');
+
+<MenuFlex>
+  <Checkbox
+    id="menuflex-example-checkbox-1"
+    checked={checkboxValue}
+    label="Are you transferring from another department?"
+    onChange={(event) => {
+      setCheckboxValue(!checkboxValue);
+    }}
+  />
+  <TextInput
+    id="menuflex-example-textinput-1"
+    value={textValue}
+    name="department"
+    label="Previous Department (if applicable)"
+    onChange={(event) => {
+      setTextValue(event.target.value);
+    }}
+    labelPosition={POSITION.TOP}
+  />
+</MenuFlex>
+```

--- a/examples/Layout/Paragraph.md
+++ b/examples/Layout/Paragraph.md
@@ -1,0 +1,8 @@
+```jsx
+<Paragraph>
+  Please select an email address using your first initial and last name unless you have a strong preference otherwise.
+</Paragraph>
+<Paragraph>
+  The part of your email address before the @ must be at least 3 and at most 20 characters long, and must consist of only lowercase letters and digits.
+</Paragraph>
+```

--- a/src/Forms/__tests__/Form.test.tsx
+++ b/src/Forms/__tests__/Form.test.tsx
@@ -1,6 +1,4 @@
-import { Button } from 'Buttons';
-import { Form, TextInput } from 'Forms';
-import { VARIANT } from 'Theme';
+import { Form } from 'Forms';
 import { strictEqual } from 'assert';
 import React from 'react';
 import { SinonStub, stub } from 'sinon';

--- a/src/Layout/MenuFlex.tsx
+++ b/src/Layout/MenuFlex.tsx
@@ -1,0 +1,18 @@
+import { PropsWithChildren, ReactElement } from 'react';
+import styled from 'styled-components';
+
+/**
+ * @component MenuFlex
+ * A flex container for a menu of items
+ */
+const MenuFlex = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: baseline;
+  align-self: center;
+`;
+
+declare type MenuFlex = ReactElement<PropsWithChildren>;
+
+export default MenuFlex;

--- a/src/Layout/Paragraph.tsx
+++ b/src/Layout/Paragraph.tsx
@@ -1,0 +1,12 @@
+import styled from 'styled-components';
+import { PropsWithChildren, ReactElement } from 'react';
+import { fromTheme } from '../Theme';
+
+const Paragraph = styled.p`
+  padding-right: 25%;
+  margin-bottom: ${fromTheme('ws', 'medium')};
+`;
+
+declare type Paragraph = ReactElement<PropsWithChildren>;
+
+export default Paragraph;

--- a/src/Layout/index.ts
+++ b/src/Layout/index.ts
@@ -2,3 +2,5 @@ export { default as Header } from './Header';
 export { default as Logo } from './Logo';
 export { default as PageBody } from './PageBody';
 export { default as Footer } from './Footer';
+export { default as Paragraph } from './Paragraph';
+export { default as MenuFlex } from './MenuFlex';


### PR DESCRIPTION
This PR adds the `MenuFlex` and `Paragraph` components from the apply.seas project. These are common layout elements that we anticipate will be used in many apps going forward. 

Unused imports were accidentally left in from the previous PR (https://github.com/seas-computing/mark-one/pull/173), and they were removed in commit [76d28df](https://github.com/seas-computing/mark-one/pull/174/commits/76d28df51f50cbfb0226c1554f1170408366c4ee).

## Describe your changes
<!--
  In a few sentences, explain what your charges will do if merged. You can also
  use this space to ask any questions about your changes, highlight particular 
  issues, and provide any additional information about how to run and/or test 
  your code.
-->

## Types of changes
<!--
  What types of changes does your code introduce? Put an `x` in all the boxes
  that apply:
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
<!--
  Go over all the following points, and put an `x` in all the boxes that apply.
-->
- [x] I have run `eslint` on the code
- [x] I have added JSDoc for all of my code (where applicable)
- [ ] I have added tests to cover my changes.

## Priority:
- [x] Normal <!-- New piece of functionality -->
- [ ] High <!-- Critical bug requiring urgent review -->

## Related Issues:
<!--
  Add the issue number in below that this PR is intended to address.

  Also mention any issues that this PR is related to, and if possible,
  provide more information regarding the relationship to the issues in
  question (i.e does the PR fix the issue, is it designed to fix another bug
  that is similar to the issue etc.)
-->
Fixes #45

<!--
  Attribution:
  PR Template adapted from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
