### PR TITLE
Update types for Modal Footer and Modal Body

### DIFF
--- a/src/Modals/ModalBody.tsx
+++ b/src/Modals/ModalBody.tsx
@@ -1,14 +1,7 @@
-import { ReactNode } from 'react';
+import { PropsWithChildren } from 'react';
 import styled, { withTheme } from 'styled-components';
 
-interface ModalBodyProps {
-  /**
-   * the content of the Modal Body
-   */
-  children: ReactNode;
-}
-
-const StyledModalBody = styled.div<ModalBodyProps>`
+const StyledModalBody = styled.div<PropsWithChildren>`
   padding: ${({ theme }): string => theme.ws.medium};
   overflow: auto;
 `;

--- a/src/Modals/ModalFooter.tsx
+++ b/src/Modals/ModalFooter.tsx
@@ -1,14 +1,7 @@
-import { ReactNode } from 'react';
+import { PropsWithChildren } from 'react';
 import styled, { withTheme } from 'styled-components';
 
-interface ModalFooterProps {
-  /**
-   * the content of the Modal Footer
-   */
-  children: ReactNode;
-}
-
-const styledModalFooter = styled.div<ModalFooterProps>`
+const styledModalFooter = styled.div<PropsWithChildren>`
   display: flex;
   flex-direction: row-reverse;
   justify-content: space-between;


### PR DESCRIPTION
This updates the `ModalBody` and `ModalFooter` to replace their prop interfaces that only contain the `children` props and replaces it with `PropsWithChildren`. This is to fix the error that we are seeing in Makerspace when trying to use `ModalBody` and `ModalFooter`: 

```
"Type '{ children: Element; }' has no properties in common with type 'IntrinsicAttributes & ExecutionProps & RefAttributes<IStyledComponent<"web", Substitute<DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement>, ModalFooterProps>>>'."
```

## Describe your changes
<!--
  In a few sentences, explain what your charges will do if merged. You can also
  use this space to ask any questions about your changes, highlight particular 
  issues, and provide any additional information about how to run and/or test 
  your code.
-->

## Types of changes
<!--
  What types of changes does your code introduce? Put an `x` in all the boxes
  that apply:
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
<!--
  Go over all the following points, and put an `x` in all the boxes that apply.
-->
- [x] I have run `eslint` on the code
- [x] I have added JSDoc for all of my code (where applicable)
- [ ] I have added tests to cover my changes.

## Priority:
- [x] Normal <!-- New piece of functionality -->
- [ ] High <!-- Critical bug requiring urgent review -->

## Related Issues:
<!--
  Add the issue number in below that this PR is intended to address.

  Also mention any issues that this PR is related to, and if possible,
  provide more information regarding the relationship to the issues in
  question (i.e does the PR fix the issue, is it designed to fix another bug
  that is similar to the issue etc.)
-->
Fixes [#44](https://github.huit.harvard.edu/SEAS/makerspace/issues/44)

<!--
  Attribution:
  PR Template adapted from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
