### PR TITLE
Fix Modal Body and Modal Footer components

### DIFF
--- a/src/Modals/ModalBody.tsx
+++ b/src/Modals/ModalBody.tsx
@@ -1,8 +1,9 @@
 import { PropsWithChildren, ReactElement } from 'react';
-import styled, { withTheme } from 'styled-components';
+import styled from 'styled-components';
+import { fromTheme } from '../Theme';
 
 const ModalBody = styled.div`
-  padding: ${({ theme }): string => theme.ws.medium};
+  padding: ${fromTheme('ws', 'medium')};
   overflow: auto;
 `;
 
@@ -13,4 +14,4 @@ declare type ModalBody = ReactElement<PropsWithChildren>;
  * Used within the Modal component to provide appropriate spacing in line with
  * the ModalHeader and ModalFooter components.
  */
-export default withTheme(ModalBody);
+export default ModalBody;

--- a/src/Modals/ModalBody.tsx
+++ b/src/Modals/ModalBody.tsx
@@ -1,14 +1,16 @@
-import { PropsWithChildren } from 'react';
+import { PropsWithChildren, ReactElement } from 'react';
 import styled, { withTheme } from 'styled-components';
 
-const StyledModalBody = styled.div<PropsWithChildren>`
+const ModalBody = styled.div`
   padding: ${({ theme }): string => theme.ws.medium};
   overflow: auto;
 `;
+
+declare type ModalBody = ReactElement<PropsWithChildren>;
 
 /**
  * @component ModalBody
  * Used within the Modal component to provide appropriate spacing in line with
  * the ModalHeader and ModalFooter components.
  */
-export default withTheme(StyledModalBody);
+export default withTheme(ModalBody);

--- a/src/Modals/ModalBody.tsx
+++ b/src/Modals/ModalBody.tsx
@@ -2,7 +2,7 @@ import { PropsWithChildren, ReactElement } from 'react';
 import styled from 'styled-components';
 import { fromTheme } from '../Theme';
 
-const ModalBody = styled.div`
+const ModalBody = styled.div<PropsWithChildren>`
   padding: ${fromTheme('ws', 'medium')};
   overflow: auto;
 `;

--- a/src/Modals/ModalFooter.tsx
+++ b/src/Modals/ModalFooter.tsx
@@ -1,7 +1,7 @@
-import { PropsWithChildren } from 'react';
+import { PropsWithChildren, ReactElement } from 'react';
 import styled, { withTheme } from 'styled-components';
 
-const styledModalFooter = styled.div<PropsWithChildren>`
+const ModalFooter = styled.div`
   display: flex;
   flex-direction: row-reverse;
   justify-content: space-between;
@@ -9,9 +9,11 @@ const styledModalFooter = styled.div<PropsWithChildren>`
   width: 100%;
 `;
 
+declare type ModalFooter = ReactElement<PropsWithChildren>;
+
 /**
  * @component ModalFooter
  * Used within the Modal component to render a separated bottom section,
  * typically containing buttons for save, cancel, etc.
  */
-export default withTheme(styledModalFooter);
+export default withTheme(ModalFooter);

--- a/src/Modals/ModalFooter.tsx
+++ b/src/Modals/ModalFooter.tsx
@@ -1,11 +1,12 @@
 import { PropsWithChildren, ReactElement } from 'react';
-import styled, { withTheme } from 'styled-components';
+import styled from 'styled-components';
+import { fromTheme } from '../Theme';
 
 const ModalFooter = styled.div`
   display: flex;
   flex-direction: row-reverse;
   justify-content: space-between;
-  padding: ${({ theme }): string => `${theme.ws.small} ${theme.ws.medium}`};
+  padding: ${fromTheme('ws', 'small')} ${fromTheme('ws', 'medium')};
   width: 100%;
 `;
 
@@ -16,4 +17,4 @@ declare type ModalFooter = ReactElement<PropsWithChildren>;
  * Used within the Modal component to render a separated bottom section,
  * typically containing buttons for save, cancel, etc.
  */
-export default withTheme(ModalFooter);
+export default ModalFooter;

--- a/src/Modals/ModalFooter.tsx
+++ b/src/Modals/ModalFooter.tsx
@@ -2,7 +2,7 @@ import { PropsWithChildren, ReactElement } from 'react';
 import styled from 'styled-components';
 import { fromTheme } from '../Theme';
 
-const ModalFooter = styled.div`
+const ModalFooter = styled.div<PropsWithChildren>`
   display: flex;
   flex-direction: row-reverse;
   justify-content: space-between;


### PR DESCRIPTION
`PropsWithChildren` was included within the definition of the types for the `ModalBody` and `ModalFooter`. These changes are in response to getting a type error message when trying to use these components in the Makerspace project related to the `children` prop.
```
Type '{ children: Element; }' has no properties in common with type 'IntrinsicAttributes & ExecutionProps & RefAttributes<IStyledComponent<"web", Substitute<DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement>, { ...; }>>>'.ts(2559)
```

## Describe your changes
<!--
  In a few sentences, explain what your charges will do if merged. You can also
  use this space to ask any questions about your changes, highlight particular 
  issues, and provide any additional information about how to run and/or test 
  your code.
-->

## Types of changes
<!--
  What types of changes does your code introduce? Put an `x` in all the boxes
  that apply:
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
<!--
  Go over all the following points, and put an `x` in all the boxes that apply.
-->
- [x] I have run `eslint` on the code
- [ x] I have added JSDoc for all of my code (where applicable)
- [ ] I have added tests to cover my changes.

## Priority:
- [x] Normal <!-- New piece of functionality -->
- [ ] High <!-- Critical bug requiring urgent review -->

## Related Issues:
<!--
  Add the issue number in below that this PR is intended to address.

  Also mention any issues that this PR is related to, and if possible,
  provide more information regarding the relationship to the issues in
  question (i.e does the PR fix the issue, is it designed to fix another bug
  that is similar to the issue etc.)
-->
Fixes [#44](https://github.huit.harvard.edu/SEAS/makerspace/issues/44)

<!--
  Attribution:
  PR Template adapted from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
