### PR TITLE
Add SectionSubHeading Component

### DIFF
--- a/examples/Typography/SectionSubHeading.md
+++ b/examples/Typography/SectionSubHeading.md
@@ -1,0 +1,7 @@
+Renders a styled `<h3>` element for denoting the heading of a new subsection within a page.
+
+For accessibility, the `<SectionSubHeading>` should be below the corresponding `<SectionHeading>` in the DOM, and should not be ordered within other heading elements.
+
+```jsx
+<SectionSubHeading>Section Subheading</SectionSubHeading>
+```

--- a/src/Theme/MarkOneTheme.ts
+++ b/src/Theme/MarkOneTheme.ts
@@ -107,6 +107,11 @@ const MarkOneTheme: DefaultTheme = {
       size: '1.33em',
       weight: WEIGHT.LIGHT,
     },
+    subheading: {
+      family: FONT.SANS,
+      size: '1.13em',
+      weight: WEIGHT.BOLD,
+    },
     error: {
       family: FONT.SANS,
       size: '0.7em',

--- a/src/Theme/ThemeTypes.ts
+++ b/src/Theme/ThemeTypes.ts
@@ -14,46 +14,51 @@ export type FontSpec = {
   color?: string;
 };
 
-export type AcademicArea = 'acs' |
-'am' |
-'ap' |
-'be' |
-'cs' |
-'ee' |
-'ese' |
-'general' |
-'mat & me' |
-'mde' |
-'msmba' |
-'sem';
+export type AcademicArea =
+  | 'acs'
+  | 'am'
+  | 'ap'
+  | 'be'
+  | 'cs'
+  | 'ee'
+  | 'ese'
+  | 'general'
+  | 'mat & me'
+  | 'mde'
+  | 'msmba'
+  | 'sem';
 
 export type ColorCategory = 'background' | 'text' | 'area';
 
-export type FontCategory = 'base' |
-'body' |
-'data' |
-'note' |
-'bold' |
-'title' |
-'heading' |
-'error' |
-'footer';
+export type FontCategory =
+  | 'base'
+  | 'body'
+  | 'data'
+  | 'note'
+  | 'bold'
+  | 'title'
+  | 'heading'
+  | 'subheading'
+  | 'error'
+  | 'footer';
 
-export type WhiteSpaceSize = 'zero' |
-'xsmall' |
-'small' |
-'medium' |
-'large' |
-'xlarge';
+export type WhiteSpaceSize =
+  | 'zero'
+  | 'xsmall'
+  | 'small'
+  | 'medium'
+  | 'large'
+  | 'xlarge';
 
 export type BorderWeight = 'hairline' | 'light' | 'heavy';
 
 export type ShadowWeight = 'xlight' | 'light' | 'medium';
 
-export type TextColors = 'base' |
-'light' |
-'medium' |
-'dark' |
-'info' |
-'positive' |
-'negative';
+export type TextColors =
+  | 'base'
+  | 'light'
+  | 'medium'
+  | 'dark'
+  | 'info'
+  | 'positive'
+  | 'negative';

--- a/src/Typography/SectionSubHeading.tsx
+++ b/src/Typography/SectionSubHeading.tsx
@@ -1,0 +1,24 @@
+import { ReactNode } from 'react';
+import styled from 'styled-components';
+
+interface SectionHeadingProps {
+  /**
+   * The content to display inside the Subheading
+   */
+  children: ReactNode;
+}
+
+const StyledSectionSubHeading = styled.h3<SectionHeadingProps>`
+  color: ${({ theme }): string => theme.color.text.dark};
+  font-family: ${({ theme }): string => theme.font.subheading.family};
+  font-size: ${({ theme }): string => theme.font.subheading.size};
+  font-weight: ${({ theme }): string => theme.font.subheading.weight};
+  margin-top: ${({ theme }): string => theme.ws.medium};
+  margin-bottom: ${({ theme }): string => theme.ws.small};
+`;
+
+/**
+ * @component SectionSubHeading
+ * Render a section subheading on the Mark One Heading styles
+ */
+export default StyledSectionSubHeading;

--- a/src/Typography/index.ts
+++ b/src/Typography/index.ts
@@ -1,3 +1,4 @@
 export { default as PageTitle } from './PageTitle';
 export { default as SectionHeading } from './SectionHeading';
 export { default as NoteText } from './NoteText';
+export { default as SectionSubHeading } from './SectionSubHeading';


### PR DESCRIPTION
This PR adds a `SectionSubHeading` component representing an h3 element. In keeping with best practices in hierarchical headings, it should only be used under a SectionHeading (i.e. h2) to break up a section of text further.

Stylistically, it is bolder than the normal text and the `SectionHeading`, and between the two in size. It also has a larger `margin-top` than `margin-bottom` to separate it from surrounding text.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
- [x] I have run `eslint` on the code
- [x] I have added JSDoc for all of my code (where applicable)
- [ ] I have added tests to cover my changes.

## Priority:
- [x] Normal
- [ ] High

## Related Issues:
#184 
