### PR TITLE
Add Callout Component

### DIFF
--- a/examples/Layout/Callout.md
+++ b/examples/Layout/Callout.md
@@ -1,0 +1,5 @@
+Renders a styled `<p>` element for displaying a piece of text intended to stand out to the user.
+
+```jsx
+<Callout>Callout text</Callout>
+```

--- a/examples/Layout/Callout.md
+++ b/examples/Layout/Callout.md
@@ -1,5 +1,25 @@
 Renders a styled `<p>` element for displaying a piece of text intended to stand out to the user.
 
+The following is an example of the default callout in which the `variant` property is assigned the default enum value `VARIANT.INFO` and the role is assigned the default value `note`.
+
 ```jsx
-<Callout>Callout text</Callout>
+import { VARIANT } from 'mark-one';
+
+<Callout>You currently have 3 shop safety certifications.</Callout>
+```
+
+The following is an example of a callout in which the `variant` property is assigned the enum value `VARIANT.POSITIVE` and the role is assigned the default value `note`.
+
+```jsx
+import { VARIANT } from 'mark-one';
+
+<Callout variant={VARIANT.POSITIVE}>Your submission has been received! Please check your inbox for a confirmation email. We will respond within the next 48 hours.</Callout>
+```
+
+The following is an example of a callout in which the `variant` property is assigned the enum value `VARIANT.NEGATIVE` and the role is assigned the value `alert`.
+
+```jsx
+import { VARIANT } from 'mark-one';
+
+<Callout variant={VARIANT.NEGATIVE} role='alert'>You must attend a lab safety training before taking this course.</Callout>
 ```

--- a/src/Layout/Callout.tsx
+++ b/src/Layout/Callout.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, ReactNode } from 'react';
+import React, { FunctionComponent, ReactNode, AriaRole } from 'react';
 import styled from 'styled-components';
 import { VARIANT } from '../Theme';
 
@@ -14,7 +14,7 @@ export interface CalloutProps {
    * https://www.w3.org/TR/wai-aria-1.1/#live_region_roles
    * The default value role is 'note'.
    */
-  role?: string;
+  role?: AriaRole;
   children: ReactNode;
 }
 

--- a/src/Layout/Callout.tsx
+++ b/src/Layout/Callout.tsx
@@ -1,0 +1,57 @@
+import React, { FunctionComponent, ReactNode } from 'react';
+import styled from 'styled-components';
+import { VARIANT } from '../Theme';
+
+export interface CalloutProps {
+  /**
+ * Allows the user to set the background color by passing in a variant property from the VARIANT enum
+ * @default VARIANT.INFO
+ */
+  variant?: VARIANT;
+  /**
+   * The aria role of the displayed callout. A list of the different role
+   * values that should be used can be found in the w3 docs:
+   * https://www.w3.org/TR/wai-aria-1.1/#live_region_roles
+   * The default value role is 'note'.
+   */
+  role?: string;
+  children: ReactNode;
+}
+
+interface StyledCalloutProps {
+  variant: VARIANT;
+}
+
+const StyledCallout = styled.p<StyledCalloutProps>`
+  font-family: ${({ theme }): string => theme.font.callout.family};
+  font-size: ${({ theme }): string => theme.font.callout.size};
+  font-weight: ${({ theme }): string => theme.font.callout.weight};
+  color: ${({ theme }): string => theme.color.text.dark};
+  background: ${({ theme, variant }): string => theme.color.background[variant].light};
+  margin-left: ${({ theme }):string => theme.ws.large};
+  margin-top: ${({ theme }):string => theme.ws.medium};
+  margin-bottom: ${({ theme }):string => theme.ws.small};
+  padding: ${({ theme }):string => theme.ws.large};
+`;
+
+const Callout: FunctionComponent<CalloutProps> = ({
+  variant = VARIANT.INFO,
+  role = 'info',
+  children,
+}) => (
+  <StyledCallout variant={variant} role={role}>
+    {children}
+  </StyledCallout>
+);
+
+Callout.defaultProps = {
+  variant: VARIANT.INFO,
+  role: 'note',
+};
+
+/**
+ * @component Callout
+ * Render a callout to display a piece of text intended to stand out to the user.
+ */
+
+export default Callout;

--- a/src/Layout/Callout.tsx
+++ b/src/Layout/Callout.tsx
@@ -28,9 +28,7 @@ const StyledCallout = styled.p<StyledCalloutProps>`
   font-weight: ${({ theme }): string => theme.font.callout.weight};
   color: ${({ theme }): string => theme.color.text.dark};
   background: ${({ theme, variant }): string => theme.color.background[variant].light};
-  margin-left: ${({ theme }):string => theme.ws.large};
-  margin-top: ${({ theme }):string => theme.ws.medium};
-  margin-bottom: ${({ theme }):string => theme.ws.small};
+  margin: ${({ theme }):string => `${theme.ws.medium} ${theme.ws.large} ${theme.ws.small} ${theme.ws.large}`};
   padding: ${({ theme }):string => theme.ws.large};
 `;
 

--- a/src/Layout/index.ts
+++ b/src/Layout/index.ts
@@ -4,3 +4,4 @@ export { default as PageBody } from './PageBody';
 export { default as Footer } from './Footer';
 export { default as Paragraph } from './Paragraph';
 export { default as MenuFlex } from './MenuFlex';
+export { default as Callout } from './Callout';

--- a/src/Theme/MarkOneTheme.ts
+++ b/src/Theme/MarkOneTheme.ts
@@ -117,6 +117,11 @@ const MarkOneTheme: DefaultTheme = {
       size: '0.7em',
       weight: WEIGHT.BOLD,
     },
+    callout: {
+      family: FONT.SANS,
+      size: '1.13em',
+      weight: WEIGHT.BOLD,
+    },
     footer: {
       family: FONT.SANS,
       size: '0.9em',

--- a/src/Theme/ThemeTypes.ts
+++ b/src/Theme/ThemeTypes.ts
@@ -40,6 +40,7 @@ export type FontCategory =
   | 'heading'
   | 'subheading'
   | 'error'
+  | 'callout'
   | 'footer';
 
 export type WhiteSpaceSize =


### PR DESCRIPTION
This PR adds a `Callout` component, which is intended to display a piece of text that should stand out to the user. It is styled on a `<p>` element, the text size is larger than the standard type, and it has extra margins to separate it from the rest of the text.

You can pass a variant property from the `VARIANT` enum to set the background color. For accessibility purposes, only the `light` option from each variant's `ColorRange` is used, and the text color will always be `dark`. Additionally, the `role` property can be set to define the ARIA role of the callout, with a default value of 'note'.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
- [x] I have run `eslint` on the code
- [x] I have added JSDoc for all of my code (where applicable)
- [ ] I have added tests to cover my changes.

## Priority:
- [x] Normal
- [ ] High

## Related Issues:
Closes #185 