### PR TITLE
Add GridWrapper Component

### DIFF
--- a/examples/Layout/GridWrapper.md
+++ b/examples/Layout/GridWrapper.md
@@ -1,0 +1,30 @@
+*Note: this example is a placeholder until the `GridContainer` and `GridItem` components are finished.
+
+The `GridWrapper` is the top-level of the grid structure. It defines the 12-column grid, with space between rows and columns. It can be used to embed grids within other components, letting us define sub-grid arrangements when needed.
+
+It does not apply any margins, padding, additional borders shadows, or other styling, which should be handled by parent/child components instead.
+
+```jsx
+    <div>
+    <h2>Small Gap (default)</h2>
+      <GridWrapper gap="small">
+        <div style={{ backgroundColor: 'lightblue', padding: '10px' }}>Item 1</div>
+        <div style={{ backgroundColor: 'lightgreen', padding: '10px' }}>Item 2</div>
+        <div style={{ backgroundColor: 'lightcoral', padding: '10px' }}>Item 3</div>
+      </GridWrapper>
+      <br/>
+      <h2>Medium Gap</h2>
+      <GridWrapper>
+        <div style={{ backgroundColor: 'lightblue', padding: '10px' }}>Item 1</div>
+        <div style={{ backgroundColor: 'lightgreen', padding: '10px' }}>Item 2</div>
+        <div style={{ backgroundColor: 'lightcoral', padding: '10px' }}>Item 3</div>
+      </GridWrapper>
+      <br/>
+      <h2>Large Gap</h2>
+      <GridWrapper gap="large">
+        <div style={{ backgroundColor: 'lightblue', padding: '10px' }}>Item 1</div>
+        <div style={{ backgroundColor: 'lightgreen', padding: '10px' }}>Item 2</div>
+        <div style={{ backgroundColor: 'lightcoral', padding: '10px' }}>Item 3</div>
+      </GridWrapper>
+      </div>
+```

--- a/examples/Layout/GridWrapper.md
+++ b/examples/Layout/GridWrapper.md
@@ -4,24 +4,35 @@ The `GridWrapper` is the top-level of the grid structure. It defines the 12-colu
 
 It does not apply any margins, padding, additional borders shadows, or other styling, which should be handled by parent/child components instead.
 
+The `gap` prop defaults to `null`, allowing the gap size to be set conditionally. If `gap` is not provided, it defaults to `small` for screen widths above 768px and `xsmall` for screen widths 768px and below.
+
 ```jsx
     <div>
-    <h2>Small Gap (default)</h2>
-      <GridWrapper gap="small">
+    <h2>Xsmall Gap</h2>
+    <p>If gap is not provided, xsmall will be used for screen widths 768px and below. To demonstrate how this gap size will appear, xsmall is being passed in here, but would not need to be in this use case.</p>
+      <GridWrapper gap='xsmall'>
         <div style={{ backgroundColor: 'lightblue', padding: '10px' }}>Item 1</div>
         <div style={{ backgroundColor: 'lightgreen', padding: '10px' }}>Item 2</div>
         <div style={{ backgroundColor: 'lightcoral', padding: '10px' }}>Item 3</div>
       </GridWrapper>
-      <br/>
-      <h2>Medium Gap</h2>
+    <br/>
+    <h2>Small Gap </h2>
+    <p>If gap is not provided, small will be used for screen widths above 768px.</p>
       <GridWrapper>
         <div style={{ backgroundColor: 'lightblue', padding: '10px' }}>Item 1</div>
         <div style={{ backgroundColor: 'lightgreen', padding: '10px' }}>Item 2</div>
         <div style={{ backgroundColor: 'lightcoral', padding: '10px' }}>Item 3</div>
       </GridWrapper>
       <br/>
+      <h2>Medium Gap</h2>
+      <GridWrapper gap='medium'>
+        <div style={{ backgroundColor: 'lightblue', padding: '10px' }}>Item 1</div>
+        <div style={{ backgroundColor: 'lightgreen', padding: '10px' }}>Item 2</div>
+        <div style={{ backgroundColor: 'lightcoral', padding: '10px' }}>Item 3</div>
+      </GridWrapper>
+      <br/>
       <h2>Large Gap</h2>
-      <GridWrapper gap="large">
+      <GridWrapper gap='large'>
         <div style={{ backgroundColor: 'lightblue', padding: '10px' }}>Item 1</div>
         <div style={{ backgroundColor: 'lightgreen', padding: '10px' }}>Item 2</div>
         <div style={{ backgroundColor: 'lightcoral', padding: '10px' }}>Item 3</div>

--- a/src/Layout/GridWrapper.tsx
+++ b/src/Layout/GridWrapper.tsx
@@ -29,7 +29,7 @@ const GridWrapper = ({ children, gap }: GridWrapperProps): JSX.Element => (
 );
 
 GridWrapper.defaultProps = {
-  gap: 'small',
+  gap: null,
 };
 
 /**

--- a/src/Layout/GridWrapper.tsx
+++ b/src/Layout/GridWrapper.tsx
@@ -1,0 +1,39 @@
+import React, { ReactNode } from 'react';
+import styled, { DefaultTheme } from 'styled-components';
+
+interface GridWrapperProps {
+  /**
+   * Optional gap size to override the default and responsive gap sizes
+   */
+  gap?: keyof DefaultTheme['ws'];
+  /**
+   * The content to display inside the GridWrapper
+   */
+  children: ReactNode;
+}
+
+const StyledGridWrapper = styled.div<GridWrapperProps>`
+  display: grid;
+  grid-template-columns: repeat(12, 1fr);
+  gap: ${({ theme, gap }) => theme.ws[gap || 'small']};
+
+  @media (max-width: 768px) {
+    gap: ${({ theme, gap }) => theme.ws[gap || 'xsmall']}; /* Smaller gap for mobile devices */
+  }
+`;
+
+const GridWrapper = ({ children, gap }: GridWrapperProps): JSX.Element => (
+  <StyledGridWrapper gap={gap}>
+    {children}
+  </StyledGridWrapper>
+);
+
+GridWrapper.defaultProps = {
+  gap: 'small',
+};
+
+/**
+ *  @component GridWrapper
+ *  The top-level of the grid structure, it defines the 12-column grid.
+ */
+export default GridWrapper;

--- a/src/Layout/index.ts
+++ b/src/Layout/index.ts
@@ -4,3 +4,4 @@ export { default as PageBody } from './PageBody';
 export { default as Footer } from './Footer';
 export { default as Paragraph } from './Paragraph';
 export { default as MenuFlex } from './MenuFlex';
+export { default as GridWrapper } from './GridWrapper';


### PR DESCRIPTION
## Describe your changes
This PR adds a `GridWrapper` component which serves as the top-level of the grid structure. It defines the 12-column grid, with space between rows and columns. It can be used to embed grids within other components, letting us define sub-grid arrangements when needed.

It provides default gap spacing and responsive gap spacing for small window sizes, both of which can be overridden by passing in a gap size using the `MarkOneTheme` `ws` values. The component does not apply any margins, padding, additional borders shadows, or other styling, which should be handled by parent/child components instead.

This PR also adds a GridWrapper markdown example, which will be replaced with a more thorough example using the `GridContainer` and `GridItem` components, once all three are complete.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
- [x] I have run `eslint` on the code
- [x] I have added JSDoc for all of my code (where applicable)
- [ ] I have added tests to cover my changes.

## Priority:
- [x] Normal
- [ ] High

## Related Issues:
Closes #181 
