### PR TITLE
Add GridContainer Component

### DIFF
--- a/examples/Layout/GridContainer.md
+++ b/examples/Layout/GridContainer.md
@@ -6,14 +6,20 @@ This example demonstrates how **different widths** affect the layout of the grid
 import { GridWrapper } from 'mark-one';
 
 <GridWrapper gap="large">
-  <GridContainer width={2} placement="left" style={{ backgroundColor: 'lightblue', padding: '10px' }}>
-    Width 2
+  <GridContainer width={2} placement="left">
+    <div style={{ backgroundColor: 'lightblue', padding: '10px' }}>
+      Width 2
+    </div>
   </GridContainer>
-  <GridContainer width={4} placement="left" style={{ backgroundColor: 'lightgreen', padding: '10px' }}>
-    Width 4
+  <GridContainer width={4} placement="left">
+    <div style={{ backgroundColor: 'lightgreen', padding: '10px' }}>
+      Width 4
+    </div>
   </GridContainer>
-  <GridContainer width={6} placement="left" style={{ backgroundColor: 'lightcoral', padding: '10px' }}>
-    Width 6
+  <GridContainer width={6} placement="left">
+    <div style={{ backgroundColor: 'lightcoral', padding: '10px' }}>
+      Width 6
+    </div>
   </GridContainer>
 </GridWrapper>
 ```
@@ -24,14 +30,20 @@ This example demonstrates how **different placements** affect the alignment of t
 import { GridWrapper } from 'mark-one';
 
 <GridWrapper gap="large">
-  <GridContainer width={4} placement="left" style={{ backgroundColor: 'lightblue', padding: '10px' }}>
-    Left Placement
+  <GridContainer width={4} placement="left">
+    <div style={{ backgroundColor: 'lightblue', padding: '10px' }}>
+      Left Placement
+    </div>
   </GridContainer>
-  <GridContainer width={4} placement="center" style={{ backgroundColor: 'lightgreen', padding: '10px' }}>
-    Center Placement
+  <GridContainer width={4} placement="center">
+    <div style={{ backgroundColor: 'lightgreen', padding: '10px' }}>
+      Center Placement
+    </div>
   </GridContainer>
-  <GridContainer width={4} placement="right" style={{ backgroundColor: 'lightcoral', padding: '10px' }}>
-    Right Placement
+  <GridContainer width={4} placement="right">
+    <div style={{ backgroundColor: 'lightcoral', padding: '10px' }}>
+      Right Placement
+    </div>
   </GridContainer>
 </GridWrapper>
 ```
@@ -42,14 +54,20 @@ This example demonstrates a combination of **different widths and placements**.
 import { GridWrapper } from 'mark-one';
 
 <GridWrapper gap="large">
-  <GridContainer width={3} placement="left" style={{ backgroundColor: 'lightblue', padding: '10px' }}>
-    Width 3, Left
+  <GridContainer width={3} placement="left">
+    <div style={{ backgroundColor: 'lightblue', padding: '10px' }}>
+      Width 3, Left
+    </div>
   </GridContainer>
-  <GridContainer width={6} placement="center" style={{ backgroundColor: 'lightgreen', padding: '10px' }}>
-    Width 6, Center
+  <GridContainer width={6} placement="center">
+    <div style={{ backgroundColor: 'lightgreen', padding: '10px' }}>
+      Width 6, Center
+    </div>
   </GridContainer>
-  <GridContainer width={3} placement="right" style={{ backgroundColor: 'lightcoral', padding: '10px' }}>
-    Width 3, Right
+  <GridContainer width={3} placement="right">
+    <div style={{ backgroundColor: 'lightcoral', padding: '10px' }}>
+      Width 3, Right
+    </div>
   </GridContainer>
 </GridWrapper>
 ```
@@ -60,14 +78,20 @@ This example demonstrates how to place items starting from **specific columns**.
 import { GridWrapper } from 'mark-one';
 
 <GridWrapper gap="small">
-  <GridContainer width={4} placement={2} style={{ backgroundColor: 'lightblue', padding: '10px' }}>
-    Start at Column 2
+  <GridContainer width={4} placement={2}>
+    <div style={{ backgroundColor: 'lightblue', padding: '10px' }}>
+      Start at Column 2
+    </div>
   </GridContainer>
-  <GridContainer width={4} placement={6} style={{ backgroundColor: 'lightgreen', padding: '10px' }}>
-    Start at Column 6
+  <GridContainer width={4} placement={6}>
+    <div style={{ backgroundColor: 'lightgreen', padding: '10px' }}>
+      Start at Column 6
+    </div>
   </GridContainer>
-  <GridContainer width={4} placement={10} style={{ backgroundColor: 'lightcoral', padding: '10px' }}>
-    Start at Column 10
+  <GridContainer width={4} placement={10}>
+    <div style={{ backgroundColor: 'lightcoral', padding: '10px' }}>
+      Start at Column 10
+    </div>
   </GridContainer>
 </GridWrapper>
 ```

--- a/examples/Layout/GridContainer.md
+++ b/examples/Layout/GridContainer.md
@@ -1,0 +1,73 @@
+The `GridContainer` is a low-level piece of the layout grid. It represents a sub-component of a larger grid, intended for use with multiple child components, and may itself contain another grid layout. It should be placed inside a `GridWrapper` and can contain `GridItem` components.
+
+This example demonstrates how **different widths** affect the layout of the grid items.
+
+```jsx
+import { GridWrapper } from 'mark-one';
+
+<GridWrapper gap="large">
+  <GridContainer width={2} placement="left" style={{ backgroundColor: 'lightblue', padding: '10px' }}>
+    Width 2
+  </GridContainer>
+  <GridContainer width={4} placement="left" style={{ backgroundColor: 'lightgreen', padding: '10px' }}>
+    Width 4
+  </GridContainer>
+  <GridContainer width={6} placement="left" style={{ backgroundColor: 'lightcoral', padding: '10px' }}>
+    Width 6
+  </GridContainer>
+</GridWrapper>
+```
+
+This example demonstrates how **different placements** affect the alignment of the grid items.
+
+```jsx
+import { GridWrapper } from 'mark-one';
+
+<GridWrapper gap="large">
+  <GridContainer width={4} placement="left" style={{ backgroundColor: 'lightblue', padding: '10px' }}>
+    Left Placement
+  </GridContainer>
+  <GridContainer width={4} placement="center" style={{ backgroundColor: 'lightgreen', padding: '10px' }}>
+    Center Placement
+  </GridContainer>
+  <GridContainer width={4} placement="right" style={{ backgroundColor: 'lightcoral', padding: '10px' }}>
+    Right Placement
+  </GridContainer>
+</GridWrapper>
+```
+
+This example demonstrates a combination of **different widths and placements**.
+
+```jsx
+import { GridWrapper } from 'mark-one';
+
+<GridWrapper gap="large">
+  <GridContainer width={3} placement="left" style={{ backgroundColor: 'lightblue', padding: '10px' }}>
+    Width 3, Left
+  </GridContainer>
+  <GridContainer width={6} placement="center" style={{ backgroundColor: 'lightgreen', padding: '10px' }}>
+    Width 6, Center
+  </GridContainer>
+  <GridContainer width={3} placement="right" style={{ backgroundColor: 'lightcoral', padding: '10px' }}>
+    Width 3, Right
+  </GridContainer>
+</GridWrapper>
+```
+
+This example demonstrates how to place items starting from **specific columns**.
+
+```jsx
+import { GridWrapper } from 'mark-one';
+
+<GridWrapper gap="small">
+  <GridContainer width={4} placement={2} style={{ backgroundColor: 'lightblue', padding: '10px' }}>
+    Start at Column 2
+  </GridContainer>
+  <GridContainer width={4} placement={6} style={{ backgroundColor: 'lightgreen', padding: '10px' }}>
+    Start at Column 6
+  </GridContainer>
+  <GridContainer width={4} placement={10} style={{ backgroundColor: 'lightcoral', padding: '10px' }}>
+    Start at Column 10
+  </GridContainer>
+</GridWrapper>
+```

--- a/examples/Layout/GridContainer.md
+++ b/examples/Layout/GridContainer.md
@@ -88,9 +88,33 @@ import { GridWrapper } from 'mark-one';
       Start at Column 6
     </div>
   </GridContainer>
-  <GridContainer width={4} placement={10}>
+  <GridContainer width={4} placement={8}>
     <div style={{ backgroundColor: 'lightcoral', padding: '10px' }}>
-      Start at Column 10
+      Start at Column 8
+    </div>
+  </GridContainer>
+</GridWrapper>
+```
+
+This example demonstrates how the Grid system handles multiple `GridContainers` with maximum widths. It may be helpful to use the Firefox DevTools to view the column layout of these components (in the DOM inspector click the `grid` button next to the `div` that surrounds these components).
+
+```jsx
+import { GridWrapper } from 'mark-one';
+
+<GridWrapper gap="small">
+  <GridContainer width={12} placement={1}>
+    <div style={{ backgroundColor: 'lightblue', padding: '10px' }}>
+      Start at Column 2
+    </div>
+  </GridContainer>
+  <GridContainer width={12} placement={6}>
+    <div style={{ backgroundColor: 'lightgreen', padding: '10px' }}>
+      Start at Column 6
+    </div>
+  </GridContainer>
+  <GridContainer width={12} placement={8}>
+    <div style={{ backgroundColor: 'lightcoral', padding: '10px' }}>
+      Start at Column 8
     </div>
   </GridContainer>
 </GridWrapper>

--- a/examples/Layout/GridWrapper.md
+++ b/examples/Layout/GridWrapper.md
@@ -1,41 +1,47 @@
-*Note: this example is a placeholder until the `GridContainer` and `GridItem` components are finished.
-
 The `GridWrapper` is the top-level of the grid structure. It defines the 12-column grid, with space between rows and columns. It can be used to embed grids within other components, letting us define sub-grid arrangements when needed.
 
 It does not apply any margins, padding, additional borders shadows, or other styling, which should be handled by parent/child components instead.
 
 The `gap` prop defaults to `null`, allowing the gap size to be set conditionally. If `gap` is not provided, it defaults to `small` for screen widths above 768px and `xsmall` for screen widths 768px and below.
 
+<br />
+
+The following example shows the **`xsmall`** gap size. To demonstrate how this gap size will appear, the `xsmall` gap size is being passed in here, but would not need to be for screen widths 768px and below.
+
 ```jsx
-    <div>
-    <h2>Xsmall Gap</h2>
-    <p>If gap is not provided, xsmall will be used for screen widths 768px and below. To demonstrate how this gap size will appear, xsmall is being passed in here, but would not need to be in this use case.</p>
-      <GridWrapper gap='xsmall'>
-        <div style={{ backgroundColor: 'lightblue', padding: '10px' }}>Item 1</div>
-        <div style={{ backgroundColor: 'lightgreen', padding: '10px' }}>Item 2</div>
-        <div style={{ backgroundColor: 'lightcoral', padding: '10px' }}>Item 3</div>
-      </GridWrapper>
-    <br/>
-    <h2>Small Gap </h2>
-    <p>If gap is not provided, small will be used for screen widths above 768px.</p>
-      <GridWrapper>
-        <div style={{ backgroundColor: 'lightblue', padding: '10px' }}>Item 1</div>
-        <div style={{ backgroundColor: 'lightgreen', padding: '10px' }}>Item 2</div>
-        <div style={{ backgroundColor: 'lightcoral', padding: '10px' }}>Item 3</div>
-      </GridWrapper>
-      <br/>
-      <h2>Medium Gap</h2>
-      <GridWrapper gap='medium'>
-        <div style={{ backgroundColor: 'lightblue', padding: '10px' }}>Item 1</div>
-        <div style={{ backgroundColor: 'lightgreen', padding: '10px' }}>Item 2</div>
-        <div style={{ backgroundColor: 'lightcoral', padding: '10px' }}>Item 3</div>
-      </GridWrapper>
-      <br/>
-      <h2>Large Gap</h2>
-      <GridWrapper gap='large'>
-        <div style={{ backgroundColor: 'lightblue', padding: '10px' }}>Item 1</div>
-        <div style={{ backgroundColor: 'lightgreen', padding: '10px' }}>Item 2</div>
-        <div style={{ backgroundColor: 'lightcoral', padding: '10px' }}>Item 3</div>
-      </GridWrapper>
-      </div>
+  <GridWrapper gap="xsmall">
+    <div style={{ backgroundColor: 'lightblue', padding: '10px' }}>Item 1</div>
+    <div style={{ backgroundColor: 'lightgreen', padding: '10px' }}>Item 2</div>
+    <div style={{ backgroundColor: 'lightcoral', padding: '10px' }}>Item 3</div>
+  </GridWrapper>
+  ```
+
+  The following example shows the default **`small`** gap size. If gap is not provided, small will be used for screen widths above 768px.
+
+  ```jsx
+  <GridWrapper>
+    <div style={{ backgroundColor: 'lightblue', padding: '10px' }}>Item 1</div>
+    <div style={{ backgroundColor: 'lightgreen', padding: '10px' }}>Item 2</div>
+    <div style={{ backgroundColor: 'lightcoral', padding: '10px' }}>Item 3</div>
+  </GridWrapper>
+```
+
+The following example shows the **`medium`** gap size.
+
+```jsx
+  <GridWrapper gap="medium">
+    <div style={{ backgroundColor: 'lightblue', padding: '10px' }}>Item 1</div>
+    <div style={{ backgroundColor: 'lightgreen', padding: '10px' }}>Item 2</div>
+    <div style={{ backgroundColor: 'lightcoral', padding: '10px' }}>Item 3</div>
+  </GridWrapper>
+  ```
+
+  The following example shows the **`large`** gap size.
+
+  ```jsx
+  <GridWrapper gap="large">
+    <div style={{ backgroundColor: 'lightblue', padding: '10px' }}>Item 1</div>
+    <div style={{ backgroundColor: 'lightgreen', padding: '10px' }}>Item 2</div>
+    <div style={{ backgroundColor: 'lightcoral', padding: '10px' }}>Item 3</div>
+  </GridWrapper>
 ```

--- a/src/Layout/GridContainer.tsx
+++ b/src/Layout/GridContainer.tsx
@@ -1,8 +1,8 @@
 import styled from 'styled-components';
-import React, { ReactNode, CSSProperties } from 'react';
+import React, { ReactNode } from 'react';
 
 type Width = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
-type Placement = 'left' | 'center' | 'right' | Exclude<Width, 12>;
+type Placement = 'left' | 'center' | 'right' | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11;
 
 interface GridContainerProps {
   /**
@@ -22,7 +22,9 @@ interface GridContainerProps {
   children: ReactNode;
 }
 
-const getGridColumnStyles = (placement: Placement, width: Width) => {
+export const getGridColumnStyles = (
+  placement: Placement, width: Width
+): string => {
   switch (placement) {
     case 'left':
       return `span ${width}`;
@@ -39,9 +41,8 @@ const getGridColumnStyles = (placement: Placement, width: Width) => {
   }
 };
 
-const StyledGridContainer = styled.div<Pick<GridContainerProps, 'placement' | 'width'>>`
-  ${({ placement, width }) => getGridColumnStyles(placement, width)};
-  
+const StyledGridContainer = styled.div<Pick<GridContainerProps, 'placement' | 'width' >>`
+  grid-column: ${({ placement, width }) => getGridColumnStyles(placement, width)}; 
 `;
 
 const GridContainer = ({
@@ -49,7 +50,10 @@ const GridContainer = ({
   placement,
   children,
 }: GridContainerProps): JSX.Element => (
-  <StyledGridContainer width={width} placement={placement}>
+  <StyledGridContainer
+    width={width}
+    placement={placement}
+  >
     {children}
   </StyledGridContainer>
 );

--- a/src/Layout/GridContainer.tsx
+++ b/src/Layout/GridContainer.tsx
@@ -25,17 +25,17 @@ interface GridContainerProps {
 const getGridColumnStyles = (placement: Placement, width: Width) => {
   switch (placement) {
     case 'left':
-      return `grid-column: span ${width};`;
+      return `span ${width}`;
     case 'center': {
       const startColumn = Math.floor((12 - width) / 2) + 1;
-      return `grid-column: ${startColumn} / span ${width};`;
+      return `${startColumn} / span ${width}`;
     }
     case 'right': {
       const endColumn = 13 - width;
-      return `grid-column: ${endColumn} / span ${width};`;
+      return `${endColumn} / span ${width}`;
     }
     default:
-      return `grid-column: ${placement} / span ${width};`;
+      return `${placement} / span ${width}`;
   }
 };
 

--- a/src/Layout/GridContainer.tsx
+++ b/src/Layout/GridContainer.tsx
@@ -1,0 +1,66 @@
+import styled from 'styled-components';
+import React, { ReactNode, CSSProperties } from 'react';
+
+type Width = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
+type Placement = 'left' | 'center' | 'right' | Exclude<Width, 12>;
+
+interface GridContainerProps {
+  /**
+   * The number of columns covered by the element in our 12-column grid.
+   * Must be within 1-12.
+   */
+  width: Width;
+  /**
+   * Where in the grid the element should appear.
+   * Valid values are `left`, `center`, `right`, or a value between 1-11,
+   * representing the first column on which the element should appear.
+   */
+  placement: Placement;
+  /**
+   * inline styles to apply to the GridContainer
+   */
+  style?: CSSProperties;
+  /**
+   * The content to display inside the GridContainer
+   */
+  children: ReactNode;
+}
+
+const getGridColumnStyles = (placement: Placement, width: Width) => {
+  switch (placement) {
+    case 'left':
+      return `grid-column: span ${width};`;
+    case 'center': {
+      const startColumn = Math.floor((12 - width) / 2) + 1;
+      return `grid-column: ${startColumn} / span ${width};`;
+    }
+    case 'right': {
+      const endColumn = 13 - width;
+      return `grid-column: ${endColumn} / span ${width};`;
+    }
+    default:
+      return `grid-column: ${placement} / span ${width};`;
+  }
+};
+
+const StyledGridContainer = styled.div<GridContainerProps>`
+  ${({ placement, width }) => getGridColumnStyles(placement, width)};
+  
+`;
+
+const GridContainer = ({
+  width,
+  placement,
+  style,
+  children,
+}: GridContainerProps): JSX.Element => (
+  <StyledGridContainer width={width} placement={placement} style={style}>
+    {children}
+  </StyledGridContainer>
+);
+
+GridContainer.defaultProps = {
+  style: undefined,
+};
+
+export default GridContainer;

--- a/src/Layout/GridContainer.tsx
+++ b/src/Layout/GridContainer.tsx
@@ -17,10 +17,6 @@ interface GridContainerProps {
    */
   placement: Placement;
   /**
-   * inline styles to apply to the GridContainer
-   */
-  style?: CSSProperties;
-  /**
    * The content to display inside the GridContainer
    */
   children: ReactNode;
@@ -51,16 +47,11 @@ const StyledGridContainer = styled.div<GridContainerProps>`
 const GridContainer = ({
   width,
   placement,
-  style,
   children,
 }: GridContainerProps): JSX.Element => (
-  <StyledGridContainer width={width} placement={placement} style={style}>
+  <StyledGridContainer width={width} placement={placement}>
     {children}
   </StyledGridContainer>
 );
-
-GridContainer.defaultProps = {
-  style: undefined,
-};
 
 export default GridContainer;

--- a/src/Layout/GridContainer.tsx
+++ b/src/Layout/GridContainer.tsx
@@ -39,7 +39,7 @@ const getGridColumnStyles = (placement: Placement, width: Width) => {
   }
 };
 
-const StyledGridContainer = styled.div<GridContainerProps>`
+const StyledGridContainer = styled.div<Pick<GridContainerProps, 'placement' | 'width'>>`
   ${({ placement, width }) => getGridColumnStyles(placement, width)};
   
 `;

--- a/src/Layout/__tests__/GridContainer.test.tsx
+++ b/src/Layout/__tests__/GridContainer.test.tsx
@@ -1,0 +1,21 @@
+import { strictEqual } from 'assert';
+import { getGridColumnStyles } from '../GridContainer';
+
+describe('getGridColumnStyles function', function () {
+  it('should return the correct grid-column value for placement "left"', function () {
+    const result = getGridColumnStyles('left', 12);
+    strictEqual(result, 'span 12');
+  });
+  it('should return the correct grid-column value for placement "center"', function () {
+    const result = getGridColumnStyles('center', 4);
+    strictEqual(result, '5 / span 4');
+  });
+  it('should return the correct grid-column value for placement "right"', function () {
+    const result = getGridColumnStyles('right', 6);
+    strictEqual(result, '7 / span 6');
+  });
+  it('should return the correct grid-column value for numbered placements', function () {
+    const result = getGridColumnStyles(7, 6);
+    strictEqual(result, '7 / span 6');
+  });
+});

--- a/src/Layout/__tests__/GridContainer.test.tsx
+++ b/src/Layout/__tests__/GridContainer.test.tsx
@@ -22,8 +22,10 @@ describe('getGridColumnStyles function', function () {
     strictEqual(getGridColumnStyles(7, 6), '7 / span 6');
     strictEqual(getGridColumnStyles(9, 5), '9 / span 5');
   });
-  it('should return the correct grid-column value for numbered placements', function () {
-    const result = getGridColumnStyles(7, 6);
-    strictEqual(result, '7 / span 6');
+  it('should return the correct grid-column value for the maximum width (e.g. 12) at any placement', function () {
+    strictEqual(getGridColumnStyles(1, 12), '1 / span 12');
+    strictEqual(getGridColumnStyles(5, 12), '5 / span 12');
+    strictEqual(getGridColumnStyles(7, 12), '7 / span 12');
+    strictEqual(getGridColumnStyles(11, 12), '11 / span 12');
   });
 });

--- a/src/Layout/__tests__/GridContainer.test.tsx
+++ b/src/Layout/__tests__/GridContainer.test.tsx
@@ -2,17 +2,25 @@ import { strictEqual } from 'assert';
 import { getGridColumnStyles } from '../GridContainer';
 
 describe('getGridColumnStyles function', function () {
-  it('should return the correct grid-column value for placement "left"', function () {
-    const result = getGridColumnStyles('left', 12);
-    strictEqual(result, 'span 12');
+  it('returns correct grid-column value for placement "left"', function () {
+    strictEqual(getGridColumnStyles('left', 1), 'span 1');
+    strictEqual(getGridColumnStyles('left', 7), 'span 7');
+    strictEqual(getGridColumnStyles('left', 12), 'span 12');
   });
-  it('should return the correct grid-column value for placement "center"', function () {
-    const result = getGridColumnStyles('center', 4);
-    strictEqual(result, '5 / span 4');
+  it('returns correct grid-column value for placement "center"', function () {
+    strictEqual(getGridColumnStyles('center', 1), '6 / span 1');
+    strictEqual(getGridColumnStyles('center', 7), '3 / span 7');
+    strictEqual(getGridColumnStyles('center', 12), '1 / span 12');
   });
-  it('should return the correct grid-column value for placement "right"', function () {
-    const result = getGridColumnStyles('right', 6);
-    strictEqual(result, '7 / span 6');
+  it('returns correct grid-column value for placement "right"', function () {
+    strictEqual(getGridColumnStyles('right', 1), '12 / span 1');
+    strictEqual(getGridColumnStyles('right', 7), '6 / span 7');
+    strictEqual(getGridColumnStyles('right', 12), '1 / span 12');
+  });
+  it('returns the correct grid-column value for numbered placements', function () {
+    strictEqual(getGridColumnStyles(4, 12), '4 / span 12');
+    strictEqual(getGridColumnStyles(7, 6), '7 / span 6');
+    strictEqual(getGridColumnStyles(9, 5), '9 / span 5');
   });
   it('should return the correct grid-column value for numbered placements', function () {
     const result = getGridColumnStyles(7, 6);

--- a/src/Layout/index.ts
+++ b/src/Layout/index.ts
@@ -6,3 +6,4 @@ export { default as Paragraph } from './Paragraph';
 export { default as MenuFlex } from './MenuFlex';
 export { default as Callout } from './Callout';
 export { default as GridWrapper } from './GridWrapper';
+export { default as GridContainer } from './GridContainer';


### PR DESCRIPTION
This PR adds a GridContainer component, which is a low-level piece of the layout grid. It represents a sub-component of a larger grid, intended for use with multiple child components, and may itself contain another grid layout. It should be placed inside a `GridWrapper` and can contain `GridItem` components (the latter of which will be added in a future enhancement).

This PR also makes some slight changes to the `GridWrapper` markdown examples, in light of the `GridContainer` examples.

This PR also provides testing for the `getGridColumnStyles` function.

With the current implementation, users may experience some unexpected behavior in the display of the `GridContainer` when the total width of multiple adjacent `GridContainers` exceeds 12. Addressing this would overly complicate the code for now, but this may be worth addressing in a future update, and may require changes in the implementation of `GridWrapper`.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
- [x] I have run `eslint` on the code
- [x] I have added JSDoc for all of my code (where applicable)
- [x] I have added tests to cover my changes.

## Priority:
- [x] Normal
- [ ] High

## Related Issues:
Closes #183 