### PR TITLE
Fix LoadSpinner Markdown Example Error

### DIFF
--- a/examples/Spinners/LoadSpinner.md
+++ b/examples/Spinners/LoadSpinner.md
@@ -10,6 +10,7 @@ To style the text to have a light color. Note that a dark background is used to 
 
 ```jsx
 import { SPINNER_TEXT } from 'mark-one';
+import styled from 'styled-components';
 
 const DarkBackground = styled.div`
   background: ${({ theme }) => theme.color.background.darker };


### PR DESCRIPTION
## Describe your changes
This fixes the `ReferenceError: styled is not defined in the styleguide` in the second markdown example for the LoadSpinner by importing styled within the markdown example. It now properly displays the light color text on dark background example.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to change)

## Checklist:
- [x] I have run `eslint` on the code
- [ ] I have added JSDoc for all of my code (where applicable)
- [ ] I have added tests to cover my changes.

## Priority:
- [x] Normal
- [ ] High

## Related Issues:
Fixes #199 
