### PR TITLE
Release v0.8.0

### DIFF
--- a/examples/Alerts/ToastNotification.md
+++ b/examples/Alerts/ToastNotification.md
@@ -1,34 +1,94 @@
+The following is an example of a Toast Notification in which the `variant` property defaults to the enum value `VARIANT.INFO`.
 ```jsx
 import { useState } from 'react';
 import { Button, VARIANT } from 'mark-one';
 
-const ToastNotificationExample = () => {
-  const [isVisible, setIsVisible] = useState(true);
-  return (
-    <>
-      {isVisible ?
-        <ToastNotification
-          id="test"
-          onClick={() => {
-            setIsVisible(false);
-          }}
-        >
-          Test Notification: Unauthorized user Jane H. tried to log in (9/9/24 3:30PM ET).
-        </ToastNotification>
-      :
-        <Button
-          id="toast-notification-example-button-1"
-          variant={VARIANT.PRIMARY}
-          onClick={() => {
-            setIsVisible(true);
-          }}
-        >
-          Show Toast Notification
-        </Button>
-      }
-    </>
-  );
-};
+const [isVisible, setIsVisible] = useState(true);
 
-<ToastNotificationExample />
+<>
+  {isVisible ?
+    <ToastNotification
+      id="test"
+      header="Upcoming Maintenance"
+      onClick={() => {
+        setIsVisible(false);
+      }}
+    >
+      System maintenance will occur on 9/22/24 between 8-10PM ET. (9/9/24 3:30PM ET).
+    </ToastNotification>
+  :
+    <Button
+      id="toast-notification-example-button-1"
+      onClick={() => {
+        setIsVisible(true);
+      }}
+    >
+      Show Toast Notification
+    </Button>
+  }
+</>
+```
+
+The following is an example of a Toast Notification in which the `variant` property is set to the enum value `VARIANT.DANGER`.
+```jsx
+import { useState } from 'react';
+import { Button, VARIANT } from 'mark-one';
+
+const [isVisible, setIsVisible] = useState(true);
+
+<>
+  {isVisible ?
+    <ToastNotification
+      id="test"
+      header="Unauthorized Login Attempt"
+      variant={VARIANT.DANGER}
+      onClick={() => {
+        setIsVisible(false);
+      }}
+    >
+      Unauthorized user Jane H. tried to log in (9/9/24 3:30PM ET).
+    </ToastNotification>
+  :
+    <Button
+      id="toast-notification-example-button-1"
+      onClick={() => {
+        setIsVisible(true);
+      }}
+    >
+      Show Toast Notification
+    </Button>
+  }
+</>
+```
+
+The following is an example of a Toast Notification in which the `variant` property is set to the enum value `VARIANT.PRIMARY`.
+```jsx
+import { useState } from 'react';
+import { Button, VARIANT } from 'mark-one';
+
+const [isVisible, setIsVisible] = useState(true);
+
+<>
+  {isVisible ?
+    <ToastNotification
+      id="test"
+      header="System Update"
+      variant={VARIANT.PRIMARY}
+      onClick={() => {
+        setIsVisible(false);
+      }}
+    >
+      The system update has completed successfully (9/9/24 3:30PM ET).
+    </ToastNotification>
+  :
+    <Button
+      id="toast-notification-example-button-1"
+      onClick={() => {
+        setIsVisible(true);
+      }}
+    >
+      Show Toast Notification
+    </Button>
+  }
+</>
 ```

--- a/examples/Alerts/ToastNotification.md
+++ b/examples/Alerts/ToastNotification.md
@@ -1,0 +1,34 @@
+```jsx
+import { useState } from 'react';
+import { Button, VARIANT } from 'mark-one';
+
+const ToastNotificationExample = () => {
+  const [isVisible, setIsVisible] = useState(true);
+  return (
+    <>
+      {isVisible ?
+        <ToastNotification
+          id="test"
+          onClick={() => {
+            setIsVisible(false);
+          }}
+        >
+          Test Notification: Unauthorized user Jane H. tried to log in (9/9/24 3:30PM ET).
+        </ToastNotification>
+      :
+        <Button
+          id="toast-notification-example-button-1"
+          variant={VARIANT.PRIMARY}
+          onClick={() => {
+            setIsVisible(true);
+          }}
+        >
+          Show Toast Notification
+        </Button>
+      }
+    </>
+  );
+};
+
+<ToastNotificationExample />
+```

--- a/examples/Alerts/ToastNotificationWrapper.md
+++ b/examples/Alerts/ToastNotificationWrapper.md
@@ -1,0 +1,227 @@
+```jsx
+import { useState, useRef, useEffect } from 'react';
+import styled from 'styled-components';
+import { Button, VARIANT, ToastNotification } from 'mark-one';
+
+const notificationRef = useRef(null);
+
+const [isExampleVisible, setIsExampleVisible] = useState(false);
+const [isInfoToastVisible, setIsInfoToastVisible] = useState(false);
+const [isDangerToast1Visible, setIsDangerToast1Visible] = useState(false);
+const [isDangerToast2Visible, setIsDangerToast2Visible] = useState(false);
+const [isDangerToast3Visible, setIsDangerToast3Visible] = useState(false);
+const [isDangerToast4Visible, setIsDangerToast4Visible] = useState(false);
+const [isDangerToast5Visible, setIsDangerToast5Visible] = useState(false);
+const [isDangerToast6Visible, setIsDangerToast6Visible] = useState(false);
+const [isDangerToast7Visible, setIsDangerToast7Visible] = useState(false);
+const [isDangerToast8Visible, setIsDangerToast8Visible] = useState(false);
+const [isPrimaryToastVisible, setIsPrimaryToastVisible] = useState(false);
+const [visibleToastCount, setVisibleToastCount] = useState(0);
+const [userStartedInteracting, setUserStartedInteracting] = useState(false);
+
+useEffect(() => {
+    const count = [
+      isInfoToastVisible,
+      isDangerToast1Visible,
+      isDangerToast2Visible,
+      isDangerToast3Visible,
+      isDangerToast4Visible,
+      isDangerToast5Visible,
+      isDangerToast6Visible,
+      isDangerToast7Visible,
+      isDangerToast8Visible,
+      isPrimaryToastVisible,
+    ].filter(Boolean).length;
+    setVisibleToastCount(count);
+  }, [
+    isInfoToastVisible,
+    isDangerToast1Visible,
+    isDangerToast2Visible,
+    isDangerToast3Visible,
+    isDangerToast4Visible,
+    isDangerToast5Visible,
+    isDangerToast6Visible,
+    isDangerToast7Visible,
+    isDangerToast8Visible,
+    isPrimaryToastVisible,
+  ]);
+
+const closeAllNotifications = () => {
+  setIsInfoToastVisible(false);
+  setIsDangerToast1Visible(false);
+  setIsPrimaryToastVisible(false);
+  setIsDangerToast2Visible(false);
+  setIsDangerToast3Visible(false);
+  setIsDangerToast4Visible(false);
+  setIsDangerToast5Visible(false);
+  setIsDangerToast6Visible(false);
+  setIsDangerToast7Visible(false);
+  setIsDangerToast8Visible(false);
+};
+
+<>
+  {!isExampleVisible || (!isInfoToastVisible && !isPrimaryToastVisible && !isDangerToast1Visible && !isDangerToast2Visible && !isDangerToast3Visible && !isDangerToast4Visible && !isDangerToast5Visible && !isDangerToast6Visible && !isDangerToast7Visible && !isDangerToast8Visible && userStartedInteracting) ?
+    <Button
+      id="toast-notification-wrapper-example-button-1"
+      onClick={() => {
+        setTimeout(() => { notificationRef.current.focus() }, 500);
+        setIsExampleVisible(true);
+        setIsInfoToastVisible(true);
+        setIsDangerToast1Visible(true);
+        setIsPrimaryToastVisible(true);
+        setIsDangerToast2Visible(true);
+        setIsDangerToast3Visible(true);
+        setIsDangerToast4Visible(true);
+        setIsDangerToast5Visible(true);
+        setIsDangerToast6Visible(true);
+        setIsDangerToast7Visible(true);
+        setIsDangerToast8Visible(true);
+        setUserStartedInteracting(true);
+      }}
+    >
+      Show Toast Notifications
+    </Button>
+    :
+    <>
+      <Button
+        id="toast-notification-wrapper-example-button-2"
+        variant={VARIANT.PRIMARY}
+        onClick={() => {
+          setIsExampleVisible(false);
+          closeAllNotifications();
+        }}
+      >
+        Hide Toast Notifications
+      </Button>
+      <ToastNotificationWrapper
+        numNotifications={visibleToastCount}
+        onClick={() => {
+          setIsExampleVisible(false);
+          closeAllNotifications();
+        }}
+      >
+        {isInfoToastVisible &&
+          <ToastNotification
+            id="toast-notification-wrapper-example-toast-1"
+            header="Upcoming Maintenance"
+            forwardRef={notificationRef}
+            onClick={function() {
+              setIsInfoToastVisible(false);
+            }}
+          >
+            System maintenance will occur on 9/22/24 between 8-10PM ET. (9/9/24 3:30PM ET).
+          </ToastNotification>
+        }
+        {isDangerToast1Visible &&
+          <ToastNotification
+            id="toast-notification-wrapper-example-toast-2"
+            header="Unauthorized Login Attempt"
+            variant={VARIANT.DANGER}
+            onClick={function() {
+              setIsDangerToast1Visible(false);
+            }}
+          >
+            Unauthorized user John H. tried to log in (9/9/24 2:11PM ET).
+          </ToastNotification>
+        }
+        {isPrimaryToastVisible &&
+          <ToastNotification
+            id="toast-notification-wrapper-example-toast-3"
+            header="System Update"
+            variant={VARIANT.PRIMARY}
+            onClick={function() {
+              setIsPrimaryToastVisible(false);
+            }}
+          >
+            The system update has completed successfully (9/9/24 2:09PM ET).
+          </ToastNotification>
+        }
+        {isDangerToast2Visible &&
+          <ToastNotification
+            id="toast-notification-wrapper-example-toast-4"
+            header="Unauthorized Login Attempt"
+            variant={VARIANT.DANGER}
+            onClick={function() {
+              setIsDangerToast2Visible(false);
+            }}
+          >
+            Unauthorized user Jane H. tried to log in (9/9/24 2:08PM ET).
+          </ToastNotification>
+        }
+        {isDangerToast3Visible &&
+          <ToastNotification
+            id="toast-notification-wrapper-example-toast-5"
+            header="Unauthorized Login Attempt"
+            variant={VARIANT.DANGER}
+            onClick={function() {
+              setIsDangerToast3Visible(false);
+            }}
+          >
+            Unauthorized user John H. tried to log in (9/9/24 2:03PM ET).
+          </ToastNotification>
+        }
+        {isDangerToast4Visible &&
+          <ToastNotification
+            id="toast-notification-wrapper-example-toast-6"
+            header="Unauthorized Login Attempt"
+            variant={VARIANT.DANGER}
+            onClick={function() {
+              setIsDangerToast4Visible(false);
+            }}
+          >
+            Unauthorized user John H. tried to log in (9/9/24 1:55PM ET).
+          </ToastNotification>
+        }
+        {isDangerToast5Visible &&
+          <ToastNotification
+            id="toast-notification-wrapper-example-toast-7"
+            header="Unauthorized Login Attempt"
+            variant={VARIANT.DANGER}
+            onClick={function() {
+              setIsDangerToast5Visible(false);
+            }}
+          >
+            Unauthorized user Jane H. tried to log in (9/9/24 1:48PM ET).
+          </ToastNotification>
+        }
+        {isDangerToast6Visible &&
+          <ToastNotification
+            id="toast-notification-wrapper-example-toast-8"
+            header="Unauthorized Login Attempt"
+            variant={VARIANT.DANGER}
+            onClick={function() {
+              setIsDangerToast6Visible(false);
+            }}
+          >
+            Unauthorized user Jane H. tried to log in (9/9/24 1:40PM ET).
+          </ToastNotification>
+        }
+        {isDangerToast7Visible &&
+          <ToastNotification
+            id="toast-notification-wrapper-example-toast-9"
+            header="Unauthorized Login Attempt"
+            variant={VARIANT.DANGER}
+            onClick={function() {
+              setIsDangerToast7Visible(false);
+            }}
+          >
+            Unauthorized user John H. tried to log in (9/9/24 1:37PM ET).
+          </ToastNotification>
+        }
+        {isDangerToast8Visible &&
+          <ToastNotification
+            id="toast-notification-wrapper-example-toast-10"
+            header="Unauthorized Login Attempt"
+            variant={VARIANT.DANGER}
+            onClick={function() {
+              setIsDangerToast8Visible(false);
+            }}
+          >
+            Unauthorized user Jane H. tried to log in (9/9/24 1:15PM ET).
+          </ToastNotification>
+        }
+      </ToastNotificationWrapper>
+    </>
+  }
+</>
+```

--- a/examples/Forms/Form.md
+++ b/examples/Forms/Form.md
@@ -134,6 +134,7 @@ const submitHandler = () => {
 }
 
 <Form
+  id="groceryListForm"
   label="Grocery List"
   submitHandler={submitHandler}
 >
@@ -151,7 +152,9 @@ const submitHandler = () => {
   </ul>
   <Button
     id="form-example-button-2"
+    form="groceryListForm"
     variant={VARIANT.PRIMARY}
+    type="submit"
   >
     Submit
   </Button>

--- a/examples/Layout/Callout.md
+++ b/examples/Layout/Callout.md
@@ -1,0 +1,25 @@
+Renders a styled `<p>` element for displaying a piece of text intended to stand out to the user.
+
+The following is an example of the default callout in which the `variant` property is assigned the default enum value `VARIANT.INFO` and the role is assigned the default value `note`.
+
+```jsx
+import { VARIANT } from 'mark-one';
+
+<Callout>You currently have 3 shop safety certifications.</Callout>
+```
+
+The following is an example of a callout in which the `variant` property is assigned the enum value `VARIANT.POSITIVE` and the role is assigned the default value `note`.
+
+```jsx
+import { VARIANT } from 'mark-one';
+
+<Callout variant={VARIANT.POSITIVE}>Your submission has been received! Please check your inbox for a confirmation email. We will respond within the next 48 hours.</Callout>
+```
+
+The following is an example of a callout in which the `variant` property is assigned the enum value `VARIANT.NEGATIVE` and the role is assigned the value `alert`.
+
+```jsx
+import { VARIANT } from 'mark-one';
+
+<Callout variant={VARIANT.NEGATIVE} role='alert'>You must attend a lab safety training before taking this course.</Callout>
+```

--- a/examples/Layout/GridContainer.md
+++ b/examples/Layout/GridContainer.md
@@ -1,0 +1,121 @@
+The `GridContainer` is a low-level piece of the layout grid. It represents a sub-component of a larger grid, intended for use with multiple child components, and may itself contain another grid layout. It should be placed inside a `GridWrapper` and can contain `GridItem` components.
+
+This example demonstrates how **different widths** affect the layout of the grid items.
+
+```jsx
+import { GridWrapper } from 'mark-one';
+
+<GridWrapper gap="large">
+  <GridContainer width={2} placement="left">
+    <div style={{ backgroundColor: 'lightblue', padding: '10px' }}>
+      Width 2
+    </div>
+  </GridContainer>
+  <GridContainer width={4} placement="left">
+    <div style={{ backgroundColor: 'lightgreen', padding: '10px' }}>
+      Width 4
+    </div>
+  </GridContainer>
+  <GridContainer width={6} placement="left">
+    <div style={{ backgroundColor: 'lightcoral', padding: '10px' }}>
+      Width 6
+    </div>
+  </GridContainer>
+</GridWrapper>
+```
+
+This example demonstrates how **different placements** affect the alignment of the grid items.
+
+```jsx
+import { GridWrapper } from 'mark-one';
+
+<GridWrapper gap="large">
+  <GridContainer width={4} placement="left">
+    <div style={{ backgroundColor: 'lightblue', padding: '10px' }}>
+      Left Placement
+    </div>
+  </GridContainer>
+  <GridContainer width={4} placement="center">
+    <div style={{ backgroundColor: 'lightgreen', padding: '10px' }}>
+      Center Placement
+    </div>
+  </GridContainer>
+  <GridContainer width={4} placement="right">
+    <div style={{ backgroundColor: 'lightcoral', padding: '10px' }}>
+      Right Placement
+    </div>
+  </GridContainer>
+</GridWrapper>
+```
+
+This example demonstrates a combination of **different widths and placements**.
+
+```jsx
+import { GridWrapper } from 'mark-one';
+
+<GridWrapper gap="large">
+  <GridContainer width={3} placement="left">
+    <div style={{ backgroundColor: 'lightblue', padding: '10px' }}>
+      Width 3, Left
+    </div>
+  </GridContainer>
+  <GridContainer width={6} placement="center">
+    <div style={{ backgroundColor: 'lightgreen', padding: '10px' }}>
+      Width 6, Center
+    </div>
+  </GridContainer>
+  <GridContainer width={3} placement="right">
+    <div style={{ backgroundColor: 'lightcoral', padding: '10px' }}>
+      Width 3, Right
+    </div>
+  </GridContainer>
+</GridWrapper>
+```
+
+This example demonstrates how to place items starting from **specific columns**.
+
+```jsx
+import { GridWrapper } from 'mark-one';
+
+<GridWrapper gap="small">
+  <GridContainer width={4} placement={2}>
+    <div style={{ backgroundColor: 'lightblue', padding: '10px' }}>
+      Start at Column 2
+    </div>
+  </GridContainer>
+  <GridContainer width={4} placement={6}>
+    <div style={{ backgroundColor: 'lightgreen', padding: '10px' }}>
+      Start at Column 6
+    </div>
+  </GridContainer>
+  <GridContainer width={4} placement={8}>
+    <div style={{ backgroundColor: 'lightcoral', padding: '10px' }}>
+      Start at Column 8
+    </div>
+  </GridContainer>
+</GridWrapper>
+```
+
+This example demonstrates how the Grid system handles multiple `GridContainers` with maximum widths. It may be helpful to use the Firefox DevTools to view the column layout of these components (in the DOM inspector click the `grid` button next to the `div` that surrounds these components).
+
+```jsx
+import { GridWrapper } from 'mark-one';
+
+<GridWrapper gap="small">
+  <GridContainer width={12} placement={1}>
+    <div style={{ backgroundColor: 'lightblue', padding: '10px' }}>
+      Start at Column 2
+    </div>
+  </GridContainer>
+  <GridContainer width={12} placement={6}>
+    <div style={{ backgroundColor: 'lightgreen', padding: '10px' }}>
+      Start at Column 6
+    </div>
+  </GridContainer>
+  <GridContainer width={12} placement={8}>
+    <div style={{ backgroundColor: 'lightcoral', padding: '10px' }}>
+      Start at Column 8
+    </div>
+  </GridContainer>
+</GridWrapper>
+```

--- a/examples/Layout/GridContainer.md
+++ b/examples/Layout/GridContainer.md
@@ -1,4 +1,4 @@
-The `GridContainer` is a low-level piece of the layout grid. It represents a sub-component of a larger grid, intended for use with multiple child components, and may itself contain another grid layout. It should be placed inside a `GridWrapper` and can contain `GridItem` components.
+The `GridContainer` is a low-level piece of the layout grid. It represents a sub-component of a larger grid, intended for use with multiple child components, and may itself contain another grid layout. It should be placed inside a `GridWrapper`.
 
 This example demonstrates how **different widths** affect the layout of the grid items.
 

--- a/examples/Layout/GridWrapper.md
+++ b/examples/Layout/GridWrapper.md
@@ -1,0 +1,41 @@
+*Note: this example is a placeholder until the `GridContainer` and `GridItem` components are finished.
+
+The `GridWrapper` is the top-level of the grid structure. It defines the 12-column grid, with space between rows and columns. It can be used to embed grids within other components, letting us define sub-grid arrangements when needed.
+
+It does not apply any margins, padding, additional borders shadows, or other styling, which should be handled by parent/child components instead.
+
+The `gap` prop defaults to `null`, allowing the gap size to be set conditionally. If `gap` is not provided, it defaults to `small` for screen widths above 768px and `xsmall` for screen widths 768px and below.
+
+```jsx
+    <div>
+    <h2>Xsmall Gap</h2>
+    <p>If gap is not provided, xsmall will be used for screen widths 768px and below. To demonstrate how this gap size will appear, xsmall is being passed in here, but would not need to be in this use case.</p>
+      <GridWrapper gap='xsmall'>
+        <div style={{ backgroundColor: 'lightblue', padding: '10px' }}>Item 1</div>
+        <div style={{ backgroundColor: 'lightgreen', padding: '10px' }}>Item 2</div>
+        <div style={{ backgroundColor: 'lightcoral', padding: '10px' }}>Item 3</div>
+      </GridWrapper>
+    <br/>
+    <h2>Small Gap </h2>
+    <p>If gap is not provided, small will be used for screen widths above 768px.</p>
+      <GridWrapper>
+        <div style={{ backgroundColor: 'lightblue', padding: '10px' }}>Item 1</div>
+        <div style={{ backgroundColor: 'lightgreen', padding: '10px' }}>Item 2</div>
+        <div style={{ backgroundColor: 'lightcoral', padding: '10px' }}>Item 3</div>
+      </GridWrapper>
+      <br/>
+      <h2>Medium Gap</h2>
+      <GridWrapper gap='medium'>
+        <div style={{ backgroundColor: 'lightblue', padding: '10px' }}>Item 1</div>
+        <div style={{ backgroundColor: 'lightgreen', padding: '10px' }}>Item 2</div>
+        <div style={{ backgroundColor: 'lightcoral', padding: '10px' }}>Item 3</div>
+      </GridWrapper>
+      <br/>
+      <h2>Large Gap</h2>
+      <GridWrapper gap='large'>
+        <div style={{ backgroundColor: 'lightblue', padding: '10px' }}>Item 1</div>
+        <div style={{ backgroundColor: 'lightgreen', padding: '10px' }}>Item 2</div>
+        <div style={{ backgroundColor: 'lightcoral', padding: '10px' }}>Item 3</div>
+      </GridWrapper>
+      </div>
+```

--- a/examples/Layout/GridWrapper.md
+++ b/examples/Layout/GridWrapper.md
@@ -1,41 +1,47 @@
-*Note: this example is a placeholder until the `GridContainer` and `GridItem` components are finished.
-
 The `GridWrapper` is the top-level of the grid structure. It defines the 12-column grid, with space between rows and columns. It can be used to embed grids within other components, letting us define sub-grid arrangements when needed.
 
 It does not apply any margins, padding, additional borders shadows, or other styling, which should be handled by parent/child components instead.
 
 The `gap` prop defaults to `null`, allowing the gap size to be set conditionally. If `gap` is not provided, it defaults to `small` for screen widths above 768px and `xsmall` for screen widths 768px and below.
 
+<br />
+
+The following example shows the **`xsmall`** gap size. To demonstrate how this gap size will appear, the `xsmall` gap size is being passed in here, but would not need to be for screen widths 768px and below.
+
 ```jsx
-    <div>
-    <h2>Xsmall Gap</h2>
-    <p>If gap is not provided, xsmall will be used for screen widths 768px and below. To demonstrate how this gap size will appear, xsmall is being passed in here, but would not need to be in this use case.</p>
-      <GridWrapper gap='xsmall'>
-        <div style={{ backgroundColor: 'lightblue', padding: '10px' }}>Item 1</div>
-        <div style={{ backgroundColor: 'lightgreen', padding: '10px' }}>Item 2</div>
-        <div style={{ backgroundColor: 'lightcoral', padding: '10px' }}>Item 3</div>
-      </GridWrapper>
-    <br/>
-    <h2>Small Gap </h2>
-    <p>If gap is not provided, small will be used for screen widths above 768px.</p>
-      <GridWrapper>
-        <div style={{ backgroundColor: 'lightblue', padding: '10px' }}>Item 1</div>
-        <div style={{ backgroundColor: 'lightgreen', padding: '10px' }}>Item 2</div>
-        <div style={{ backgroundColor: 'lightcoral', padding: '10px' }}>Item 3</div>
-      </GridWrapper>
-      <br/>
-      <h2>Medium Gap</h2>
-      <GridWrapper gap='medium'>
-        <div style={{ backgroundColor: 'lightblue', padding: '10px' }}>Item 1</div>
-        <div style={{ backgroundColor: 'lightgreen', padding: '10px' }}>Item 2</div>
-        <div style={{ backgroundColor: 'lightcoral', padding: '10px' }}>Item 3</div>
-      </GridWrapper>
-      <br/>
-      <h2>Large Gap</h2>
-      <GridWrapper gap='large'>
-        <div style={{ backgroundColor: 'lightblue', padding: '10px' }}>Item 1</div>
-        <div style={{ backgroundColor: 'lightgreen', padding: '10px' }}>Item 2</div>
-        <div style={{ backgroundColor: 'lightcoral', padding: '10px' }}>Item 3</div>
-      </GridWrapper>
-      </div>
+  <GridWrapper gap="xsmall">
+    <div style={{ backgroundColor: 'lightblue', padding: '10px' }}>Item 1</div>
+    <div style={{ backgroundColor: 'lightgreen', padding: '10px' }}>Item 2</div>
+    <div style={{ backgroundColor: 'lightcoral', padding: '10px' }}>Item 3</div>
+  </GridWrapper>
+  ```
+
+  The following example shows the default **`small`** gap size. If gap is not provided, small will be used for screen widths above 768px.
+
+  ```jsx
+  <GridWrapper>
+    <div style={{ backgroundColor: 'lightblue', padding: '10px' }}>Item 1</div>
+    <div style={{ backgroundColor: 'lightgreen', padding: '10px' }}>Item 2</div>
+    <div style={{ backgroundColor: 'lightcoral', padding: '10px' }}>Item 3</div>
+  </GridWrapper>
+```
+
+The following example shows the **`medium`** gap size.
+
+```jsx
+  <GridWrapper gap="medium">
+    <div style={{ backgroundColor: 'lightblue', padding: '10px' }}>Item 1</div>
+    <div style={{ backgroundColor: 'lightgreen', padding: '10px' }}>Item 2</div>
+    <div style={{ backgroundColor: 'lightcoral', padding: '10px' }}>Item 3</div>
+  </GridWrapper>
+  ```
+
+  The following example shows the **`large`** gap size.
+
+  ```jsx
+  <GridWrapper gap="large">
+    <div style={{ backgroundColor: 'lightblue', padding: '10px' }}>Item 1</div>
+    <div style={{ backgroundColor: 'lightgreen', padding: '10px' }}>Item 2</div>
+    <div style={{ backgroundColor: 'lightcoral', padding: '10px' }}>Item 3</div>
+  </GridWrapper>
 ```

--- a/examples/Layout/MenuFlex.md
+++ b/examples/Layout/MenuFlex.md
@@ -1,0 +1,30 @@
+A flex container to display a menu of items:
+
+```jsx
+import { useState } from 'react';
+import { Checkbox, TextInput, POSITION } from 'mark-one';
+
+const [checkboxValue, setCheckboxValue] = useState(false);
+const [textValue, setTextValue] = useState('');
+
+<MenuFlex>
+  <Checkbox
+    id="menuflex-example-checkbox-1"
+    checked={checkboxValue}
+    label="Are you transferring from another department?"
+    onChange={(event) => {
+      setCheckboxValue(!checkboxValue);
+    }}
+  />
+  <TextInput
+    id="menuflex-example-textinput-1"
+    value={textValue}
+    name="department"
+    label="Previous Department (if applicable)"
+    onChange={(event) => {
+      setTextValue(event.target.value);
+    }}
+    labelPosition={POSITION.TOP}
+  />
+</MenuFlex>
+```

--- a/examples/Layout/Paragraph.md
+++ b/examples/Layout/Paragraph.md
@@ -1,0 +1,8 @@
+```jsx
+<Paragraph>
+  Please select an email address using your first initial and last name unless you have a strong preference otherwise.
+</Paragraph>
+<Paragraph>
+  The part of your email address before the @ must be at least 3 and at most 20 characters long, and must consist of only lowercase letters and digits.
+</Paragraph>
+```

--- a/examples/Spinners/LoadSpinner.md
+++ b/examples/Spinners/LoadSpinner.md
@@ -10,6 +10,7 @@ To style the text to have a light color. Note that a dark background is used to 
 
 ```jsx
 import { SPINNER_TEXT } from 'mark-one';
+import styled from 'styled-components';
 
 const DarkBackground = styled.div`
   background: ${({ theme }) => theme.color.background.darker };

--- a/examples/Typography/SectionSubHeading.md
+++ b/examples/Typography/SectionSubHeading.md
@@ -1,0 +1,7 @@
+Renders a styled `<h3>` element for denoting the heading of a new subsection within a page.
+
+For accessibility, the `<SectionSubHeading>` should be below the corresponding `<SectionHeading>` in the DOM, and should not be ordered within other heading elements.
+
+```jsx
+<SectionSubHeading>Section Subheading</SectionSubHeading>
+```

--- a/examples/Typography/Stat.md
+++ b/examples/Typography/Stat.md
@@ -1,0 +1,58 @@
+Can be used to style inline text representing data or statistics, such as the scores in the table below.
+
+ ```jsx
+import {
+  ALIGN,
+  Table,
+  TableCell,
+  TableBody,
+  TableRow,
+  TableHeadingCell,
+  TableHead,
+} from 'mark-one';
+
+<Table>
+  <TableHead>
+    <TableRow>
+      <TableHeadingCell scope={'col'}>ID</TableHeadingCell>
+      <TableHeadingCell scope={'col'}>First Name</TableHeadingCell>
+      <TableHeadingCell scope={'col'}>Last Name</TableHeadingCell>
+      <TableHeadingCell scope={'col'}>Score</TableHeadingCell>
+    </TableRow>
+  </TableHead>
+  <TableBody isScrollable={true}>
+    <TableRow isStriped={true}>
+      <TableCell alignment={ALIGN.LEFT}>1</TableCell>
+      <TableCell alignment={ALIGN.LEFT}>Kristin</TableCell>
+      <TableCell alignment={ALIGN.LEFT}>Glenn</TableCell>
+      <TableCell alignment={ALIGN.RIGHT}>
+          <Stat>1234</Stat>
+      </TableCell>
+    </TableRow>
+    <TableRow>
+      <TableCell alignment={ALIGN.LEFT}>2</TableCell>
+      <TableCell alignment={ALIGN.LEFT}>Jack</TableCell>
+      <TableCell alignment={ALIGN.LEFT}>Thompson</TableCell>
+      <TableCell alignment={ALIGN.RIGHT}>
+          <Stat>2121</Stat>
+      </TableCell>
+    </TableRow>
+    <TableRow isStriped={true}>
+      <TableCell alignment={ALIGN.LEFT}>3</TableCell>
+      <TableCell alignment={ALIGN.LEFT}>Lianne</TableCell>
+      <TableCell alignment={ALIGN.LEFT}>Michaels</TableCell>
+      <TableCell alignment={ALIGN.RIGHT}>
+          <Stat>4321</Stat>
+      </TableCell>
+    </TableRow>
+    <TableRow>
+      <TableCell alignment={ALIGN.LEFT}>4</TableCell>
+      <TableCell alignment={ALIGN.LEFT}>Gabriela</TableCell>
+      <TableCell alignment={ALIGN.LEFT}>Hines</TableCell>
+      <TableCell alignment={ALIGN.RIGHT}>
+          <Stat>925</Stat>
+      </TableCell>
+    </TableRow>
+  </TableBody>
+</Table>
+ ```

--- a/examples/Typography/TextDisplay.md
+++ b/examples/Typography/TextDisplay.md
@@ -1,0 +1,18 @@
+A corollary to the `TextInput`, the `TextDisplay` is intended for displaying a labeled piece of non-editable, informational text.
+
+Label example: the optional `labelPosition` prop defaults to `POSITION.LEFT`.
+
+```jsx
+<TextDisplay id="example" label="Description" value="Display Text"></TextDisplay>
+```
+
+Label example: `labelPosition` prop is set to `POSITION.TOP`.
+```jsx
+<TextDisplay id="example" label="Description" value="Display Text" labelPosition="top"></TextDisplay>
+```
+
+Label example: the optional `isLabelVisible` prop is set to false.
+
+```jsx
+<TextDisplay id="example" label="Description" value="Display Text" isLabelVisible={false}></TextDisplay>
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mark-one",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mark-one",
-      "version": "0.7.5",
+      "version": "0.7.6",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^1.2.26",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mark-one",
-  "version": "0.7.10",
+  "version": "0.7.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mark-one",
-      "version": "0.7.10",
+      "version": "0.7.11",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^1.2.26",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mark-one",
-  "version": "0.7.9",
+  "version": "0.7.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mark-one",
-      "version": "0.7.9",
+      "version": "0.7.10",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^1.2.26",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mark-one",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mark-one",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^1.2.26",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mark-one",
-  "version": "0.7.8",
+  "version": "0.7.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mark-one",
-      "version": "0.7.8",
+      "version": "0.7.9",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^1.2.26",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mark-one",
-  "version": "0.7.12",
+  "version": "0.7.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mark-one",
-      "version": "0.7.12",
+      "version": "0.7.13",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^1.2.26",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mark-one",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mark-one",
-      "version": "0.7.2",
+      "version": "0.7.3",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^1.2.26",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mark-one",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mark-one",
-      "version": "0.7.7",
+      "version": "0.7.8",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^1.2.26",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mark-one",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mark-one",
-      "version": "0.7.4",
+      "version": "0.7.5",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^1.2.26",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mark-one",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mark-one",
-      "version": "0.7.3",
+      "version": "0.7.4",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^1.2.26",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mark-one",
-  "version": "0.7.13",
+  "version": "0.7.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mark-one",
-      "version": "0.7.13",
+      "version": "0.7.14",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^1.2.26",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mark-one",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mark-one",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^1.2.26",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mark-one",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mark-one",
-      "version": "0.7.6",
+      "version": "0.7.7",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^1.2.26",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mark-one",
-  "version": "0.7.11",
+  "version": "0.7.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mark-one",
-      "version": "0.7.11",
+      "version": "0.7.12",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^1.2.26",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mark-one",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "A UI component library for building React Apps",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mark-one",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "A UI component library for building React Apps",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mark-one",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "description": "A UI component library for building React Apps",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mark-one",
-  "version": "0.7.11",
+  "version": "0.7.12",
   "description": "A UI component library for building React Apps",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mark-one",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "A UI component library for building React Apps",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mark-one",
-  "version": "0.7.13",
+  "version": "0.7.14",
   "description": "A UI component library for building React Apps",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mark-one",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "A UI component library for building React Apps",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mark-one",
-  "version": "0.7.8",
+  "version": "0.7.9",
   "description": "A UI component library for building React Apps",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mark-one",
-  "version": "0.7.12",
+  "version": "0.7.13",
   "description": "A UI component library for building React Apps",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mark-one",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "A UI component library for building React Apps",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mark-one",
-  "version": "0.7.9",
+  "version": "0.7.10",
   "description": "A UI component library for building React Apps",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mark-one",
-  "version": "0.7.10",
+  "version": "0.7.11",
   "description": "A UI component library for building React Apps",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mark-one",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "A UI component library for building React Apps",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mark-one",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "description": "A UI component library for building React Apps",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/Alerts/ToastNotification.tsx
+++ b/src/Alerts/ToastNotification.tsx
@@ -3,20 +3,24 @@ import React, {
   ReactElement,
   MouseEventHandler,
   Ref,
+  useContext,
 } from 'react';
-import styled from 'styled-components';
-import { faTimes } from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { VARIANT } from 'Theme';
+import styled, { ThemeContext } from 'styled-components';
 import { ARIA_LIVE_VARIANT } from '../const';
-import BorderlessButton from '../Buttons/BorderlessButton';
-import { fromTheme } from '../Theme';
+import { fromTheme, VARIANT } from '../Theme';
+import { Button } from '../Buttons';
 
 export interface ToastNotificationProps {
   /** The id of the notification */
   id: string;
+  /**
+   * Displays the overall purpose of the notification
+   */
+  header?: string;
   /** Text to be displayed */
   children: string;
+  /** Allows you to pass in a variant property from the VARIANT enum */
+  variant?: VARIANT;
   /** The aria role of the message displayed. A list of the different role
    * values that should be used can be found in the w3 docs:
    * https://www.w3.org/TR/wai-aria-1.1/#live_region_roles
@@ -26,13 +30,23 @@ export interface ToastNotificationProps {
   /** The value of the aria-live property */
   ariaLive?: ARIA_LIVE_VARIANT;
   /** Specifies the ref of the element */
-  forwardRef?: Ref<HTMLButtonElement>;
+  forwardRef?: Ref<HTMLDivElement>;
   /** Function to call on click event */
   onClick: MouseEventHandler;
 }
 
+interface StyledToastNotificationProps {
+  /** Allows you to pass in a variant property from the VARIANT enum */
+  variant: VARIANT;
+}
+
+const Header = styled.h2`
+  color: ${fromTheme('color', 'text', 'dark')};
+  font-size: ${fromTheme('font', 'bold', 'size')};
+`;
+
 const TextContainer = styled.div`
-  color: ${fromTheme('color', 'text', 'light')};
+  color: ${fromTheme('color', 'text', 'dark')};
   font-size: ${fromTheme('font', 'note', 'size')};
   grid-area: text;
 `;
@@ -43,13 +57,13 @@ const ButtonContainer = styled.div`
   grid-area: button;
 `;
 
-const StyledToastNotification = styled.div`
-  background: ${fromTheme('color', 'background', 'dark')};
-  border: 1px solid ${fromTheme('color', 'background', 'dark')};
+const StyledToastNotification = styled.div<StyledToastNotificationProps>`
+  background: ${fromTheme('color', 'background', 'light')};
+  border: 3px solid ${({ theme, variant }) => theme.color.background[variant].dark};
   display: grid;
   grid-template: "text button" / 3fr 1fr;
   margin-bottom: 0.25em;
-  padding: 0.75em;
+  padding: 1em;
   width: 20em;
   z-index: 1000;
 `;
@@ -58,36 +72,52 @@ const ToastNotification: FunctionComponent<ToastNotificationProps> = (props)
 : ReactElement => {
   const {
     id,
+    header,
     children,
+    variant,
     role,
     ariaLive,
     forwardRef,
     onClick,
   } = props;
 
+  const theme = useContext(ThemeContext);
+
   return (
     <StyledToastNotification
       id={id}
+      variant={variant}
+      theme={theme}
       role={role}
       aria-live={ariaLive}
+      tabIndex={-1}
+      ref={forwardRef}
     >
-      <TextContainer>{children}</TextContainer>
+      <TextContainer>
+        {header && (
+          <Header>
+            {header}
+          </Header>
+        )}
+        {children}
+      </TextContainer>
       <ButtonContainer>
-        <BorderlessButton
+        <Button
           id={`${id} button`}
           alt={`${id} close button`}
           onClick={onClick}
-          variant={VARIANT.DANGER}
-          forwardRef={forwardRef}
+          variant={VARIANT.BASE}
         >
-          <FontAwesomeIcon icon={faTimes} size="lg" />
-        </BorderlessButton>
+          Close
+        </Button>
       </ButtonContainer>
     </StyledToastNotification>
   );
 };
 
 ToastNotification.defaultProps = {
+  header: '',
+  variant: VARIANT.INFO,
   role: 'alert',
   ariaLive: ARIA_LIVE_VARIANT.ASSERTIVE,
   forwardRef: null,

--- a/src/Alerts/ToastNotification.tsx
+++ b/src/Alerts/ToastNotification.tsx
@@ -1,0 +1,96 @@
+import React, {
+  FunctionComponent,
+  ReactElement,
+  MouseEventHandler,
+  Ref,
+} from 'react';
+import styled from 'styled-components';
+import { faTimes } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { VARIANT } from 'Theme';
+import { ARIA_LIVE_VARIANT } from '../const';
+import BorderlessButton from '../Buttons/BorderlessButton';
+import { fromTheme } from '../Theme';
+
+export interface ToastNotificationProps {
+  /** The id of the notification */
+  id: string;
+  /** Text to be displayed */
+  children: string;
+  /** The aria role of the message displayed. A list of the different role
+   * values that should be used can be found in the w3 docs:
+   * https://www.w3.org/TR/wai-aria-1.1/#live_region_roles
+   * The default value role is 'alert.'
+   * */
+  role?: string;
+  /** The value of the aria-live property */
+  ariaLive?: ARIA_LIVE_VARIANT;
+  /** Specifies the ref of the element */
+  forwardRef?: Ref<HTMLButtonElement>;
+  /** Function to call on click event */
+  onClick: MouseEventHandler;
+}
+
+const TextContainer = styled.div`
+  color: ${fromTheme('color', 'text', 'light')};
+  font-size: ${fromTheme('font', 'note', 'size')};
+  grid-area: text;
+`;
+
+const ButtonContainer = styled.div`
+  align-self: center;
+  text-align: right;
+  grid-area: button;
+`;
+
+const StyledToastNotification = styled.div`
+  background: ${fromTheme('color', 'background', 'dark')};
+  border: 1px solid ${fromTheme('color', 'background', 'dark')};
+  display: grid;
+  grid-template: "text button" / 3fr 1fr;
+  margin-bottom: 0.25em;
+  padding: 0.75em;
+  width: 20em;
+  z-index: 1000;
+`;
+
+const ToastNotification: FunctionComponent<ToastNotificationProps> = (props)
+: ReactElement => {
+  const {
+    id,
+    children,
+    role,
+    ariaLive,
+    forwardRef,
+    onClick,
+  } = props;
+
+  return (
+    <StyledToastNotification
+      id={id}
+      role={role}
+      aria-live={ariaLive}
+    >
+      <TextContainer>{children}</TextContainer>
+      <ButtonContainer>
+        <BorderlessButton
+          id={`${id} button`}
+          alt={`${id} close button`}
+          onClick={onClick}
+          variant={VARIANT.DANGER}
+          forwardRef={forwardRef}
+        >
+          <FontAwesomeIcon icon={faTimes} size="lg" />
+        </BorderlessButton>
+      </ButtonContainer>
+    </StyledToastNotification>
+  );
+};
+
+ToastNotification.defaultProps = {
+  role: 'alert',
+  ariaLive: ARIA_LIVE_VARIANT.ASSERTIVE,
+  forwardRef: null,
+};
+
+export default ToastNotification;

--- a/src/Alerts/ToastNotificationWrapper.tsx
+++ b/src/Alerts/ToastNotificationWrapper.tsx
@@ -1,0 +1,88 @@
+import React, {
+  FunctionComponent,
+  MouseEventHandler,
+  ReactElement,
+  ReactNode,
+} from 'react';
+import styled from 'styled-components';
+import { Button } from '../Buttons';
+import { VARIANT, fromTheme } from '../Theme';
+
+export interface ToastNotificationWrapperProps {
+  /** Elements to be displayed within the wrapper */
+  children: ReactNode;
+  /** Function to call on click event */
+  onClick: MouseEventHandler;
+  /** Indicates how many notifications there are within the wrapper */
+  numNotifications?: number;
+}
+
+const StyledToastNotificationWrapper = styled.div`
+  display: flex;
+  align-self: flex-end;
+  flex-direction: column;
+  height: 100vh;
+  overflow-y: scroll;
+  padding-bottom: 0.75em;
+  position: fixed;
+  top: 0.25em;
+  right: 0.25em;
+  scrollbar-gutter: stable;
+  z-index: 1000;
+`;
+
+// A wrapper component to horizontally center content
+const CenterContainer = styled.div`
+  color: ${fromTheme('color', 'text', 'dark')};
+  font-size: ${fromTheme('font', 'note', 'size')};
+  justify-content: center;
+  display: flex;
+`;
+
+// A helper function to determine the message related to the
+// total number of notifications
+const renderNotificationMessage = (numNotifications: number) => {
+  if (numNotifications === 0) {
+    return '';
+  } if (numNotifications === 1) {
+    return `${numNotifications} notification to review`;
+  }
+  return `${numNotifications} notifications to review`;
+};
+
+/**
+ * A wrapper for the ToastNotification component to position them at the top
+ * right of the page.
+ */
+const ToastNotificationWrapper
+: FunctionComponent<ToastNotificationWrapperProps> = (props): ReactElement => {
+  const {
+    children,
+    onClick,
+    numNotifications,
+  } = props;
+
+  return (
+    <StyledToastNotificationWrapper>
+      <CenterContainer>
+        {renderNotificationMessage(numNotifications)}
+      </CenterContainer>
+      {children}
+      <CenterContainer>
+        <Button
+          id="close all button"
+          variant={VARIANT.BASE}
+          onClick={onClick}
+        >
+          Close All Notifications
+        </Button>
+      </CenterContainer>
+    </StyledToastNotificationWrapper>
+  );
+};
+
+ToastNotificationWrapper.defaultProps = {
+  numNotifications: 0,
+};
+
+export default ToastNotificationWrapper;

--- a/src/Alerts/__tests__/ToastNotification.test.tsx
+++ b/src/Alerts/__tests__/ToastNotification.test.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { strictEqual } from 'assert';
+import {
+  render,
+  fireEvent,
+  BoundFunction,
+  GetByText,
+} from 'test-utils';
+import {
+  spy,
+  SinonSpy,
+} from 'sinon';
+import { ToastNotification } from 'Alerts';
+
+describe('Toast Notification', function () {
+  let getByText: BoundFunction<GetByText>;
+  let getByLabelText: BoundFunction<GetByText>;
+  let clickSpy: SinonSpy;
+  const id = 'test';
+  const alertMessage = 'Test Notification';
+  const buttonAltText = `${id} close button`;
+  beforeEach(function () {
+    clickSpy = spy();
+    ({ getByText, getByLabelText } = render(
+      <ToastNotification
+        id={id}
+        onClick={clickSpy}
+      >
+        Test Notification
+      </ToastNotification>
+    ));
+  });
+  afterEach(function () {
+    clickSpy.resetHistory();
+  });
+  it('renders the message', function () {
+    getByText(alertMessage);
+  });
+  it('calls the click handler when the close button is clicked', function () {
+    fireEvent.click(getByLabelText(buttonAltText));
+    strictEqual(clickSpy.callCount, 1);
+  });
+});

--- a/src/Alerts/index.ts
+++ b/src/Alerts/index.ts
@@ -1,2 +1,3 @@
 export { default as GlobalMessage } from './GlobalMessage';
 export { default as MessageContext } from './MessageContext';
+export { default as ToastNotification } from './ToastNotification';

--- a/src/Alerts/index.ts
+++ b/src/Alerts/index.ts
@@ -1,3 +1,4 @@
 export { default as GlobalMessage } from './GlobalMessage';
 export { default as MessageContext } from './MessageContext';
 export { default as ToastNotification } from './ToastNotification';
+export { default as ToastNotificationWrapper } from './ToastNotificationWrapper';

--- a/src/Buttons/Button.tsx
+++ b/src/Buttons/Button.tsx
@@ -5,6 +5,7 @@ import React, {
   ReactNode,
   MouseEventHandler,
   Ref,
+  ButtonHTMLAttributes,
 } from 'react';
 import styled, { ThemeContext } from 'styled-components';
 import {
@@ -30,6 +31,8 @@ export interface ButtonProps extends MarkOneProps<HTMLButtonElement> {
   form?: string;
   /** Specifies the ref of the element */
   forwardRef?: Ref<HTMLButtonElement>;
+  /** Specifies the button type */
+  type?: ButtonHTMLAttributes<HTMLButtonElement>['type'];
 }
 
 const StyledButton = styled.button<ButtonProps>`
@@ -66,6 +69,7 @@ const Button: FunctionComponent<ButtonProps> = (props): ReactElement => {
     alt,
     className,
     form,
+    type,
   } = props;
   const theme = useContext(ThemeContext);
   return (
@@ -79,6 +83,7 @@ const Button: FunctionComponent<ButtonProps> = (props): ReactElement => {
       aria-label={alt}
       className={className}
       form={form}
+      type={type}
     >
       { children }
     </StyledButton>
@@ -91,6 +96,7 @@ Button.defaultProps = {
   disabled: false,
   form: '',
   forwardRef: null,
+  type: 'button',
 };
 
 export default Button;

--- a/src/Forms/Form.tsx
+++ b/src/Forms/Form.tsx
@@ -2,20 +2,22 @@ import {
   FunctionComponent,
   FormEventHandler,
   FormEvent,
+  PropsWithChildren,
 } from 'react';
 import styled from 'styled-components';
 import { fromTheme } from '../Theme';
 
 export interface FormProps {
   /** The id of the form */
-  id?: string;
+  id: string;
   /** A label that specifies the purpose of the form */
   label: string;
   /** Handler attached to the onSubmit handler */
   submitHandler?: FormEventHandler<HTMLFormElement>
 }
 
-const Form: FunctionComponent<FormProps> = styled.form.attrs<FormProps>(
+const Form: FunctionComponent<PropsWithChildren<FormProps>> = styled
+  .form.attrs<FormProps>(
   (props: FormProps) => ({
     id: props.id,
     'aria-label': props.label,
@@ -29,5 +31,9 @@ const Form: FunctionComponent<FormProps> = styled.form.attrs<FormProps>(
     margin: ${fromTheme('ws', 'small')};
   }
 `;
+
+Form.defaultProps = {
+  submitHandler: () => {},
+};
 
 export default Form;

--- a/src/Forms/__tests__/Form.test.tsx
+++ b/src/Forms/__tests__/Form.test.tsx
@@ -1,4 +1,6 @@
-import { Form } from 'Forms';
+import { Button } from 'Buttons';
+import { Form, TextInput } from 'Forms';
+import { VARIANT } from 'Theme';
 import { strictEqual } from 'assert';
 import React from 'react';
 import { SinonStub, stub } from 'sinon';

--- a/src/Forms/__tests__/Form.test.tsx
+++ b/src/Forms/__tests__/Form.test.tsx
@@ -1,6 +1,4 @@
-import { Button } from 'Buttons';
-import { Form, TextInput } from 'Forms';
-import { VARIANT } from 'Theme';
+import { Form } from 'Forms';
 import { strictEqual } from 'assert';
 import React from 'react';
 import { SinonStub, stub } from 'sinon';

--- a/src/Layout/Callout.tsx
+++ b/src/Layout/Callout.tsx
@@ -1,0 +1,55 @@
+import React, { FunctionComponent, ReactNode, AriaRole } from 'react';
+import styled from 'styled-components';
+import { VARIANT } from '../Theme';
+
+export interface CalloutProps {
+  /**
+ * Allows the user to set the background color by passing in a variant property from the VARIANT enum
+ * @default VARIANT.INFO
+ */
+  variant?: VARIANT;
+  /**
+   * The aria role of the displayed callout. A list of the different role
+   * values that should be used can be found in the w3 docs:
+   * https://www.w3.org/TR/wai-aria-1.1/#live_region_roles
+   * The default value role is 'note'.
+   */
+  role?: AriaRole;
+  children: ReactNode;
+}
+
+interface StyledCalloutProps {
+  variant: VARIANT;
+}
+
+const StyledCallout = styled.p<StyledCalloutProps>`
+  font-family: ${({ theme }): string => theme.font.callout.family};
+  font-size: ${({ theme }): string => theme.font.callout.size};
+  font-weight: ${({ theme }): string => theme.font.callout.weight};
+  color: ${({ theme }): string => theme.color.text.dark};
+  background: ${({ theme, variant }): string => theme.color.background[variant].light};
+  margin: ${({ theme }):string => `${theme.ws.medium} ${theme.ws.large} ${theme.ws.small} ${theme.ws.large}`};
+  padding: ${({ theme }):string => theme.ws.large};
+`;
+
+const Callout: FunctionComponent<CalloutProps> = ({
+  variant = VARIANT.INFO,
+  role = 'info',
+  children,
+}) => (
+  <StyledCallout variant={variant} role={role}>
+    {children}
+  </StyledCallout>
+);
+
+Callout.defaultProps = {
+  variant: VARIANT.INFO,
+  role: 'note',
+};
+
+/**
+ * @component Callout
+ * Render a callout to display a piece of text intended to stand out to the user.
+ */
+
+export default Callout;

--- a/src/Layout/GridContainer.tsx
+++ b/src/Layout/GridContainer.tsx
@@ -1,0 +1,61 @@
+import styled from 'styled-components';
+import React, { ReactNode } from 'react';
+
+type Width = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
+type Placement = 'left' | 'center' | 'right' | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11;
+
+interface GridContainerProps {
+  /**
+   * The number of columns covered by the element in our 12-column grid.
+   * Must be within 1-12.
+   */
+  width: Width;
+  /**
+   * Where in the grid the element should appear.
+   * Valid values are `left`, `center`, `right`, or a value between 1-11,
+   * representing the first column on which the element should appear.
+   */
+  placement: Placement;
+  /**
+   * The content to display inside the GridContainer
+   */
+  children: ReactNode;
+}
+
+export const getGridColumnStyles = (
+  placement: Placement, width: Width
+): string => {
+  switch (placement) {
+    case 'left':
+      return `span ${width}`;
+    case 'center': {
+      const startColumn = Math.floor((12 - width) / 2) + 1;
+      return `${startColumn} / span ${width}`;
+    }
+    case 'right': {
+      const endColumn = 13 - width;
+      return `${endColumn} / span ${width}`;
+    }
+    default:
+      return `${placement} / span ${width}`;
+  }
+};
+
+const StyledGridContainer = styled.div<Pick<GridContainerProps, 'placement' | 'width' >>`
+  grid-column: ${({ placement, width }) => getGridColumnStyles(placement, width)}; 
+`;
+
+const GridContainer = ({
+  width,
+  placement,
+  children,
+}: GridContainerProps): JSX.Element => (
+  <StyledGridContainer
+    width={width}
+    placement={placement}
+  >
+    {children}
+  </StyledGridContainer>
+);
+
+export default GridContainer;

--- a/src/Layout/GridWrapper.tsx
+++ b/src/Layout/GridWrapper.tsx
@@ -1,0 +1,39 @@
+import React, { ReactNode } from 'react';
+import styled, { DefaultTheme } from 'styled-components';
+
+interface GridWrapperProps {
+  /**
+   * Optional gap size to override the default and responsive gap sizes
+   */
+  gap?: keyof DefaultTheme['ws'];
+  /**
+   * The content to display inside the GridWrapper
+   */
+  children: ReactNode;
+}
+
+const StyledGridWrapper = styled.div<GridWrapperProps>`
+  display: grid;
+  grid-template-columns: repeat(12, 1fr);
+  gap: ${({ theme, gap }) => theme.ws[gap || 'small']};
+
+  @media (max-width: 768px) {
+    gap: ${({ theme, gap }) => theme.ws[gap || 'xsmall']}; /* Smaller gap for mobile devices */
+  }
+`;
+
+const GridWrapper = ({ children, gap }: GridWrapperProps): JSX.Element => (
+  <StyledGridWrapper gap={gap}>
+    {children}
+  </StyledGridWrapper>
+);
+
+GridWrapper.defaultProps = {
+  gap: null,
+};
+
+/**
+ *  @component GridWrapper
+ *  The top-level of the grid structure, it defines the 12-column grid.
+ */
+export default GridWrapper;

--- a/src/Layout/MenuFlex.tsx
+++ b/src/Layout/MenuFlex.tsx
@@ -1,0 +1,18 @@
+import { PropsWithChildren, ReactElement } from 'react';
+import styled from 'styled-components';
+
+/**
+ * @component MenuFlex
+ * A flex container for a menu of items
+ */
+const MenuFlex = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: baseline;
+  align-self: center;
+`;
+
+declare type MenuFlex = ReactElement<PropsWithChildren>;
+
+export default MenuFlex;

--- a/src/Layout/Paragraph.tsx
+++ b/src/Layout/Paragraph.tsx
@@ -1,0 +1,12 @@
+import styled from 'styled-components';
+import { PropsWithChildren, ReactElement } from 'react';
+import { fromTheme } from '../Theme';
+
+const Paragraph = styled.p`
+  padding-right: 25%;
+  margin-bottom: ${fromTheme('ws', 'medium')};
+`;
+
+declare type Paragraph = ReactElement<PropsWithChildren>;
+
+export default Paragraph;

--- a/src/Layout/__tests__/GridContainer.test.tsx
+++ b/src/Layout/__tests__/GridContainer.test.tsx
@@ -1,0 +1,31 @@
+import { strictEqual } from 'assert';
+import { getGridColumnStyles } from '../GridContainer';
+
+describe('getGridColumnStyles function', function () {
+  it('returns correct grid-column value for placement "left"', function () {
+    strictEqual(getGridColumnStyles('left', 1), 'span 1');
+    strictEqual(getGridColumnStyles('left', 7), 'span 7');
+    strictEqual(getGridColumnStyles('left', 12), 'span 12');
+  });
+  it('returns correct grid-column value for placement "center"', function () {
+    strictEqual(getGridColumnStyles('center', 1), '6 / span 1');
+    strictEqual(getGridColumnStyles('center', 7), '3 / span 7');
+    strictEqual(getGridColumnStyles('center', 12), '1 / span 12');
+  });
+  it('returns correct grid-column value for placement "right"', function () {
+    strictEqual(getGridColumnStyles('right', 1), '12 / span 1');
+    strictEqual(getGridColumnStyles('right', 7), '6 / span 7');
+    strictEqual(getGridColumnStyles('right', 12), '1 / span 12');
+  });
+  it('returns the correct grid-column value for numbered placements', function () {
+    strictEqual(getGridColumnStyles(4, 12), '4 / span 12');
+    strictEqual(getGridColumnStyles(7, 6), '7 / span 6');
+    strictEqual(getGridColumnStyles(9, 5), '9 / span 5');
+  });
+  it('should return the correct grid-column value for the maximum width (e.g. 12) at any placement', function () {
+    strictEqual(getGridColumnStyles(1, 12), '1 / span 12');
+    strictEqual(getGridColumnStyles(5, 12), '5 / span 12');
+    strictEqual(getGridColumnStyles(7, 12), '7 / span 12');
+    strictEqual(getGridColumnStyles(11, 12), '11 / span 12');
+  });
+});

--- a/src/Layout/index.ts
+++ b/src/Layout/index.ts
@@ -2,3 +2,5 @@ export { default as Header } from './Header';
 export { default as Logo } from './Logo';
 export { default as PageBody } from './PageBody';
 export { default as Footer } from './Footer';
+export { default as Paragraph } from './Paragraph';
+export { default as MenuFlex } from './MenuFlex';

--- a/src/Layout/index.ts
+++ b/src/Layout/index.ts
@@ -5,3 +5,4 @@ export { default as Footer } from './Footer';
 export { default as Paragraph } from './Paragraph';
 export { default as MenuFlex } from './MenuFlex';
 export { default as Callout } from './Callout';
+export { default as GridWrapper } from './GridWrapper';

--- a/src/Layout/index.ts
+++ b/src/Layout/index.ts
@@ -4,3 +4,4 @@ export { default as PageBody } from './PageBody';
 export { default as Footer } from './Footer';
 export { default as Paragraph } from './Paragraph';
 export { default as MenuFlex } from './MenuFlex';
+export { default as Callout } from './Callout';

--- a/src/Layout/index.ts
+++ b/src/Layout/index.ts
@@ -6,3 +6,4 @@ export { default as Paragraph } from './Paragraph';
 export { default as MenuFlex } from './MenuFlex';
 export { default as Callout } from './Callout';
 export { default as GridWrapper } from './GridWrapper';
+export { default as GridContainer } from './GridContainer';

--- a/src/Modals/ModalBody.tsx
+++ b/src/Modals/ModalBody.tsx
@@ -1,14 +1,7 @@
-import { ReactNode } from 'react';
+import { PropsWithChildren } from 'react';
 import styled, { withTheme } from 'styled-components';
 
-interface ModalBodyProps {
-  /**
-   * the content of the Modal Body
-   */
-  children: ReactNode;
-}
-
-const StyledModalBody = styled.div<ModalBodyProps>`
+const StyledModalBody = styled.div<PropsWithChildren>`
   padding: ${({ theme }): string => theme.ws.medium};
   overflow: auto;
 `;

--- a/src/Modals/ModalBody.tsx
+++ b/src/Modals/ModalBody.tsx
@@ -1,14 +1,17 @@
-import { PropsWithChildren } from 'react';
-import styled, { withTheme } from 'styled-components';
+import { PropsWithChildren, ReactElement } from 'react';
+import styled from 'styled-components';
+import { fromTheme } from '../Theme';
 
-const StyledModalBody = styled.div<PropsWithChildren>`
-  padding: ${({ theme }): string => theme.ws.medium};
+const ModalBody = styled.div<PropsWithChildren>`
+  padding: ${fromTheme('ws', 'medium')};
   overflow: auto;
 `;
+
+declare type ModalBody = ReactElement<PropsWithChildren>;
 
 /**
  * @component ModalBody
  * Used within the Modal component to provide appropriate spacing in line with
  * the ModalHeader and ModalFooter components.
  */
-export default withTheme(StyledModalBody);
+export default ModalBody;

--- a/src/Modals/ModalFooter.tsx
+++ b/src/Modals/ModalFooter.tsx
@@ -1,14 +1,7 @@
-import { ReactNode } from 'react';
+import { PropsWithChildren } from 'react';
 import styled, { withTheme } from 'styled-components';
 
-interface ModalFooterProps {
-  /**
-   * the content of the Modal Footer
-   */
-  children: ReactNode;
-}
-
-const styledModalFooter = styled.div<ModalFooterProps>`
+const styledModalFooter = styled.div<PropsWithChildren>`
   display: flex;
   flex-direction: row-reverse;
   justify-content: space-between;

--- a/src/Modals/ModalFooter.tsx
+++ b/src/Modals/ModalFooter.tsx
@@ -1,17 +1,20 @@
-import { PropsWithChildren } from 'react';
-import styled, { withTheme } from 'styled-components';
+import { PropsWithChildren, ReactElement } from 'react';
+import styled from 'styled-components';
+import { fromTheme } from '../Theme';
 
-const styledModalFooter = styled.div<PropsWithChildren>`
+const ModalFooter = styled.div<PropsWithChildren>`
   display: flex;
   flex-direction: row-reverse;
   justify-content: space-between;
-  padding: ${({ theme }): string => `${theme.ws.small} ${theme.ws.medium}`};
+  padding: ${fromTheme('ws', 'small')} ${fromTheme('ws', 'medium')};
   width: 100%;
 `;
+
+declare type ModalFooter = ReactElement<PropsWithChildren>;
 
 /**
  * @component ModalFooter
  * Used within the Modal component to render a separated bottom section,
  * typically containing buttons for save, cancel, etc.
  */
-export default withTheme(styledModalFooter);
+export default ModalFooter;

--- a/src/Theme/MarkOneTheme.ts
+++ b/src/Theme/MarkOneTheme.ts
@@ -117,6 +117,11 @@ const MarkOneTheme: DefaultTheme = {
       size: '0.7em',
       weight: WEIGHT.BOLD,
     },
+    callout: {
+      family: FONT.SANS,
+      size: '1.13em',
+      weight: WEIGHT.BOLD,
+    },
     footer: {
       family: FONT.SANS,
       size: '0.9em',

--- a/src/Theme/MarkOneTheme.ts
+++ b/src/Theme/MarkOneTheme.ts
@@ -107,6 +107,11 @@ const MarkOneTheme: DefaultTheme = {
       size: '1.33em',
       weight: WEIGHT.LIGHT,
     },
+    subheading: {
+      family: FONT.SANS,
+      size: '1.13em',
+      weight: WEIGHT.BOLD,
+    },
     error: {
       family: FONT.SANS,
       size: '0.7em',

--- a/src/Theme/ThemeTypes.ts
+++ b/src/Theme/ThemeTypes.ts
@@ -40,6 +40,7 @@ export type FontCategory =
   | 'heading'
   | 'subheading'
   | 'error'
+  | 'callout'
   | 'footer';
 
 export type WhiteSpaceSize =

--- a/src/Theme/ThemeTypes.ts
+++ b/src/Theme/ThemeTypes.ts
@@ -14,46 +14,51 @@ export type FontSpec = {
   color?: string;
 };
 
-export type AcademicArea = 'acs' |
-'am' |
-'ap' |
-'be' |
-'cs' |
-'ee' |
-'ese' |
-'general' |
-'mat & me' |
-'mde' |
-'msmba' |
-'sem';
+export type AcademicArea =
+  | 'acs'
+  | 'am'
+  | 'ap'
+  | 'be'
+  | 'cs'
+  | 'ee'
+  | 'ese'
+  | 'general'
+  | 'mat & me'
+  | 'mde'
+  | 'msmba'
+  | 'sem';
 
 export type ColorCategory = 'background' | 'text' | 'area';
 
-export type FontCategory = 'base' |
-'body' |
-'data' |
-'note' |
-'bold' |
-'title' |
-'heading' |
-'error' |
-'footer';
+export type FontCategory =
+  | 'base'
+  | 'body'
+  | 'data'
+  | 'note'
+  | 'bold'
+  | 'title'
+  | 'heading'
+  | 'subheading'
+  | 'error'
+  | 'footer';
 
-export type WhiteSpaceSize = 'zero' |
-'xsmall' |
-'small' |
-'medium' |
-'large' |
-'xlarge';
+export type WhiteSpaceSize =
+  | 'zero'
+  | 'xsmall'
+  | 'small'
+  | 'medium'
+  | 'large'
+  | 'xlarge';
 
 export type BorderWeight = 'hairline' | 'light' | 'heavy';
 
 export type ShadowWeight = 'xlight' | 'light' | 'medium';
 
-export type TextColors = 'base' |
-'light' |
-'medium' |
-'dark' |
-'info' |
-'positive' |
-'negative';
+export type TextColors =
+  | 'base'
+  | 'light'
+  | 'medium'
+  | 'dark'
+  | 'info'
+  | 'positive'
+  | 'negative';

--- a/src/Typography/SectionSubHeading.tsx
+++ b/src/Typography/SectionSubHeading.tsx
@@ -1,0 +1,24 @@
+import { ReactNode } from 'react';
+import styled from 'styled-components';
+
+interface SectionHeadingProps {
+  /**
+   * The content to display inside the Subheading
+   */
+  children: ReactNode;
+}
+
+const StyledSectionSubHeading = styled.h3<SectionHeadingProps>`
+  color: ${({ theme }): string => theme.color.text.dark};
+  font-family: ${({ theme }): string => theme.font.subheading.family};
+  font-size: ${({ theme }): string => theme.font.subheading.size};
+  font-weight: ${({ theme }): string => theme.font.subheading.weight};
+  margin-top: ${({ theme }): string => theme.ws.medium};
+  margin-bottom: ${({ theme }): string => theme.ws.small};
+`;
+
+/**
+ * @component SectionSubHeading
+ * Render a section subheading on the Mark One Heading styles
+ */
+export default StyledSectionSubHeading;

--- a/src/Typography/Stat.tsx
+++ b/src/Typography/Stat.tsx
@@ -1,0 +1,21 @@
+import { ReactNode } from 'react';
+import styled from 'styled-components';
+
+interface StatProps {
+  /**
+   * The data or statistics to be styled by this component
+   */
+  children: ReactNode;
+}
+
+const StyledStat = styled.span<StatProps>`
+  font-family: ${({ theme }): string => theme.font.data.family};
+  font-size: ${({ theme }): string => theme.font.data.size};
+  font-weight: ${({ theme }): string => theme.font.data.weight};
+`;
+
+/**
+ * @component Stat
+ * Style inline text representing data or statistics
+ */
+export default StyledStat;

--- a/src/Typography/TextDisplay.tsx
+++ b/src/Typography/TextDisplay.tsx
@@ -1,0 +1,99 @@
+import React, { ReactElement, FunctionComponent } from 'react';
+import styled from 'styled-components';
+import { fromTheme } from '../Theme';
+
+// An enum that represents the possible values for the label's positioning
+export enum POSITION {
+  TOP = 'top',
+  LEFT = 'left',
+}
+
+export interface TextDisplayProps {
+  /** The id of the label tied to this text display field */
+  id: string;
+  /** Specifies the label text */
+  label: string;
+  /** The name of the text display field */
+  name: string;
+  /** The current value in the text display field */
+  value: string;
+  /** Allows you to pass in a label position property from the POSITION enum
+   * @default POSITION.LEFT
+   */
+  labelPosition?: POSITION;
+  /** If true, label will be visible
+   * @default true
+   */
+  isLabelVisible?: boolean;
+}
+
+export interface StyledDisplayLabelProps {
+  /** Allows you to pass in a label position property from the POSITION enum
+   * @default POSITION.LEFT
+   */
+  labelPosition?: POSITION;
+}
+
+export const StyledTextDisplay = styled.div<TextDisplayProps>`
+  border: ${fromTheme('border', 'hairline')};
+  padding: ${fromTheme('ws', 'xsmall')};
+  display: inline-block;
+  width: fit-content;
+  ${({ labelPosition }) => labelPosition === POSITION.LEFT
+    && `display: flex;
+    align-items: center;
+  `}
+`;
+
+export const StyledDisplayLabel = styled.div<StyledDisplayLabelProps>`
+  font-weight: bold;
+  margin-bottom: ${({ labelPosition }) => (labelPosition === POSITION.TOP ? '0.5em' : '0')};
+  margin-right: ${({ labelPosition }) => (labelPosition === POSITION.LEFT ? '0.5em' : '0')};
+`;
+
+export const StyledContainer = styled.div<StyledDisplayLabelProps>`
+  display: flex;
+  flex-direction: ${({ labelPosition }) => (labelPosition === POSITION.LEFT ? 'row' : 'column')};
+  align-items: ${({ labelPosition }) => (labelPosition === POSITION.LEFT ? 'center' : 'flex-start')};
+`;
+
+/** A text display component that incorporates a styled label and styled label text */
+
+const TextDisplay: FunctionComponent<TextDisplayProps> = (
+  props
+): ReactElement => {
+  const {
+    id,
+    label,
+    name,
+    value,
+    isLabelVisible,
+    labelPosition,
+  } = props;
+  return (
+    <StyledContainer labelPosition={labelPosition}>
+      {isLabelVisible && (
+        <StyledDisplayLabel labelPosition={labelPosition}>
+          {label}
+        </StyledDisplayLabel>
+      )}
+      <StyledTextDisplay
+        id={id}
+        name={name}
+        label={label}
+        value={value}
+        labelPosition={labelPosition}
+      >
+        {value}
+      </StyledTextDisplay>
+    </StyledContainer>
+  );
+};
+
+TextDisplay.defaultProps = {
+  isLabelVisible: true,
+  labelPosition: POSITION.LEFT,
+};
+
+/** @component */
+export default TextDisplay;

--- a/src/Typography/index.ts
+++ b/src/Typography/index.ts
@@ -2,3 +2,4 @@ export { default as PageTitle } from './PageTitle';
 export { default as SectionHeading } from './SectionHeading';
 export { default as NoteText } from './NoteText';
 export { default as SectionSubHeading } from './SectionSubHeading';
+export { default as Stat } from './Stat';

--- a/src/Typography/index.ts
+++ b/src/Typography/index.ts
@@ -2,4 +2,5 @@ export { default as PageTitle } from './PageTitle';
 export { default as SectionHeading } from './SectionHeading';
 export { default as NoteText } from './NoteText';
 export { default as SectionSubHeading } from './SectionSubHeading';
+export { default as TextDisplay } from './TextDisplay';
 export { default as Stat } from './Stat';

--- a/src/Typography/index.ts
+++ b/src/Typography/index.ts
@@ -1,3 +1,4 @@
 export { default as PageTitle } from './PageTitle';
 export { default as SectionHeading } from './SectionHeading';
 export { default as NoteText } from './NoteText';
+export { default as SectionSubHeading } from './SectionSubHeading';


### PR DESCRIPTION
## New Features
- Add `MenuFlex` and `Paragraph` components for layout (closes https://github.huit.harvard.edu/SEAS/makerspace/issues/45)
- Add `SectionSubHeading` component for layout (closes #184)
- Add `Stat` component (closes #186)
- Add `Callout` component (closes #185)
- Add `GridWrapper` component (closes #181)
- Add `ToastNotification` component (closes #193)
- Add `GridContainer` component (closes #183)
- Add `ToastNotificationWrapper` component (closes #197)

## Bug Fixes
- Fix `Form` and `Button` components (part of https://github.huit.harvard.edu/SEAS/makerspace/issues/40)
- Update types for `Modal Footer` and `Modal Body` (part of https://github.huit.harvard.edu/SEAS/makerspace/issues/44)
- Fix `LoadSpinner` Markdown example to make sure that component actually renders (closes #199)
- Update documentation to remove mention of `GridItem`, which will no longer be implemented (closes #201)