### PR TITLE
Create FlexWrapper

### DIFF
--- a/examples/Layout/FlexWrapper.md
+++ b/examples/Layout/FlexWrapper.md
@@ -1,4 +1,4 @@
-Provides a flexible layout container for arranging child elements. All CSS values associated with the `flex-direction`, `justify-content` and `align-items` attributes are optionally available.
+Provides a flexible layout container for arranging child elements. All CSS values associated with the `flexDirection`, `justifyContent` and `alignItems` attributes are optionally available.
 
 In this example, two FlexWrappers are being used. A FlexWrapper is surrounding both the TextDisplay and the Table, with `alignItems` set to `flex-end` so that both hug the right side of the display area. The `gap` property is set to 'medium' to provide sufficient spacing between items. The second FlexWrapper is being used to arrange the 'Confirm' and 'Cancel' buttons in the second row of the Table. In this FlexWrapper, the `justifyContent` prop is set to 'space-evenly' while the other props use the default settings.
 
@@ -48,7 +48,7 @@ import { ALIGN, Button, Stat, Table, TableBody, TableCell, TableHead, TableHeadi
 </FlexWrapper>
 ```
 
-This example demonstrates a column orientation and nested FlexWrappers with different values for some of the props. The nested FlexWrapper around the buttons also makes use of the gap property, which is necessary for providing spacing when flex items are in column orientation.
+In this example an outer `FlexWrapper` centers the items in a column `flexDirection`. The nested FlexWrapper uses 'row' `flexDirection` to arrange the Comboboxes side by side. Both FlexWrappers make use of the `gap` property to provide adequate spacing.
 
 ```jsx
 import { useState } from 'react';

--- a/examples/Layout/FlexWrapper.md
+++ b/examples/Layout/FlexWrapper.md
@@ -1,0 +1,124 @@
+Provides a flexible layout container for arranging child elements. All CSS values associated with the `flex-direction`, `justify-content` and `align-items` attributes are optionally available.
+
+In this example, two FlexWrappers are being used. A FlexWrapper is surrounding both the TextDisplay and the Table, with `alignItems` set to `flex-end` so that both hug the right side of the display area. The `gap` property is set to 'medium' to provide sufficient spacing between items. The second FlexWrapper is being used to arrange the 'Confirm' and 'Cancel' buttons in the second row of the Table. In this FlexWrapper, the `justifyContent` prop is set to 'space-evenly' while the other props use the default settings.
+
+```jsx
+import { ALIGN, Button, Stat, Table, TableBody, TableCell, TableHead, TableHeadingCell, TableRow, TextDisplay, VARIANT } from 'mark-one';
+
+<FlexWrapper flexDirection='column' alignItems='flex-end' gap='medium'>
+  <TextDisplay id="numKiosks" label="Number of Kiosks" value='2'></TextDisplay>
+  <Table>
+    <TableHead>
+      <TableRow>
+        <TableHeadingCell scope='col'>Kiosk Name</TableHeadingCell>
+        <TableHeadingCell scope='col'>Status</TableHeadingCell>
+        <TableHeadingCell scope='col'>Update Activation</TableHeadingCell>
+      </TableRow>
+    </TableHead>
+    <TableBody>
+      <TableRow>
+        <TableCell alignment={ALIGN.CENTER}>
+            'Kiosk A'
+        </TableCell>
+        <TableCell alignment={ALIGN.CENTER}>'Active'</TableCell>
+        <TableCell alignment={ALIGN.CENTER}>
+            <Button variant={VARIANT.DANGER}>
+                Deactivate
+              </Button>
+        </TableCell>
+      </TableRow>
+      <TableRow>
+        <TableCell alignment={ALIGN.CENTER}>
+          'Kiosk B'
+        </TableCell>
+          <TableCell alignment={ALIGN.CENTER}>'Pending'</TableCell>
+          <TableCell alignment={ALIGN.CENTER}>
+            <FlexWrapper justifyContent='space-evenly'>
+              <Button variant={VARIANT.PRIMARY}>
+              Confirm
+              </Button>
+              <Button variant={VARIANT.DANGER} >
+              Cancel
+              </Button>
+            </FlexWrapper>
+          </TableCell>
+        </TableRow>
+    </TableBody>
+  </Table>
+</FlexWrapper>
+```
+
+This example demonstrates a column orientation and nested FlexWrappers with different values for some of the props. The nested FlexWrapper around the buttons also makes use of the gap property, which is necessary for providing spacing when flex items are in column orientation.
+
+```jsx
+import { useState } from 'react';
+import { Callout, Combobox, Paragraph, SectionHeading, VARIANT } from 'mark-one';
+
+const foodOptions = [
+  {
+    label: 'Apples',
+    value: 'a',
+  },
+  {
+    label: 'Bananas',
+    value: 'b',
+  },
+  {
+    label: 'Cucumbers',
+    value: 'c',
+  },
+  {
+    label: 'Donuts',
+    value: 'd',
+  }
+];
+
+const drinkOptions = [
+  {
+    label: 'Apple juice',
+    value: 'a',
+  },
+  {
+    label: 'Banana smoothie',
+    value: 'b',
+  },
+  {
+    label: 'Coke',
+    value: 'c',
+  },
+  {
+    label: 'Dr. Pepper',
+    value: 'd',
+  }
+];
+
+const [valueOne, setValueOne] = useState(null);
+const [valueTwo, setValueTwo] = useState(null);
+
+<FlexWrapper flexDirection='column' justifyContent='center' alignItems='center' gap='xlarge'>
+  <SectionHeading>Preferences</SectionHeading>
+  <Callout variant={VARIANT.INFO} role='alert'>
+  Select an item from each menu below.
+  </Callout>
+  <FlexWrapper flexDirection='row' justifyContent='space-between' gap='medium'>
+  <Combobox
+    isLabelVisible={true}
+    options={foodOptions}
+    label='Food'
+    currentValue={valueOne}
+    onOptionSelected={({ selectedItem }) => {setValueOne(selectedItem)}}
+  />
+  <Combobox
+    isLabelVisible={true}
+    options={drinkOptions}
+    label='Drink'
+    currentValue={valueTwo}
+    onOptionSelected={({ selectedItem }) => {setValueTwo(selectedItem)}}
+  />
+  </FlexWrapper>
+    <Paragraph>
+    You chose: <strong>{valueOne && valueTwo ? valueOne.label + ' and ' + valueTwo.label : ''}</strong>
+  </Paragraph>
+</FlexWrapper>
+```
+

--- a/src/Layout/FlexWrapper.tsx
+++ b/src/Layout/FlexWrapper.tsx
@@ -30,16 +30,19 @@ export interface FlexWrapperProps {
 }
 
 const StyledFlexWrapper = styled.div<FlexWrapperProps>`
-display: flex;
-flex-direction: ${({ flexDirection }) => flexDirection};
-justify-content: ${({ justifyContent }) => justifyContent};
-align-items: ${({ alignItems }) => alignItems};
-gap: ${({ theme, gap }) => theme.ws[gap]};
-
+  display: flex;
+  flex-direction: ${({ flexDirection }) => flexDirection};
+  justify-content: ${({ justifyContent }) => justifyContent};
+  align-items: ${({ alignItems }) => alignItems};
+  gap: ${({ theme, gap }) => theme.ws[gap]};
 `;
 
 const FlexWrapper = ({
-  flexDirection, justifyContent, alignItems, gap, children,
+  flexDirection,
+  justifyContent,
+  alignItems,
+  gap,
+  children,
 }: FlexWrapperProps): JSX.Element => (
   <StyledFlexWrapper
     flexDirection={flexDirection}

--- a/src/Layout/FlexWrapper.tsx
+++ b/src/Layout/FlexWrapper.tsx
@@ -12,11 +12,11 @@ export interface FlexWrapperProps {
    */
   flexDirection?: CSS.Property.FlexDirection;
   /**
-   * Control alignment of flex items on the main axis (optional)
+   * Controls alignment of flex items on the main axis (optional)
    */
   justifyContent?: CSS.Property.JustifyContent;
   /**
-   * Control alignment of flex items on the cross axis (optional)
+   * Controls alignment of flex items on the cross axis (optional)
    */
   alignItems?: CSS.Property.AlignItems;
   /**

--- a/src/Layout/FlexWrapper.tsx
+++ b/src/Layout/FlexWrapper.tsx
@@ -55,7 +55,7 @@ FlexWrapper.defaultProps = {
   flexDirection: 'row',
   justifyContent: 'flex-start',
   alignItems: 'baseline',
-  gap: null,
+  gap: 'zero',
 };
 
 /**

--- a/src/Layout/FlexWrapper.tsx
+++ b/src/Layout/FlexWrapper.tsx
@@ -1,0 +1,65 @@
+import React, { ReactNode } from 'react';
+import styled, { DefaultTheme } from 'styled-components';
+import CSS from 'csstype';
+
+/**
+ * All CSS values are available for the CSS properties below
+ */
+export interface FlexWrapperProps {
+  /**
+   * Sets how items are placed in the flex container,
+   * defining the main axis and the direction (optional)
+   */
+  flexDirection?: CSS.Property.FlexDirection;
+  /**
+   * Control alignment of flex items on the main axis (optional)
+   */
+  justifyContent?: CSS.Property.JustifyContent;
+  /**
+   * Control alignment of flex items on the cross axis (optional)
+   */
+  alignItems?: CSS.Property.AlignItems;
+  /**
+   * Provides spacing for flex items based on DefaultTheme values (optional)
+   */
+  gap?: keyof DefaultTheme['ws'];
+  /**
+   * The content to display inside the FlexWrapper
+   */
+  children: ReactNode;
+}
+
+const StyledFlexWrapper = styled.div<FlexWrapperProps>`
+display: flex;
+flex-direction: ${({ flexDirection }) => flexDirection};
+justify-content: ${({ justifyContent }) => justifyContent};
+align-items: ${({ alignItems }) => alignItems};
+gap: ${({ theme, gap }) => theme.ws[gap]};
+
+`;
+
+const FlexWrapper = ({
+  flexDirection, justifyContent, alignItems, gap, children,
+}: FlexWrapperProps): JSX.Element => (
+  <StyledFlexWrapper
+    flexDirection={flexDirection}
+    justifyContent={justifyContent}
+    alignItems={alignItems}
+    gap={gap}
+  >
+    {children}
+  </StyledFlexWrapper>
+);
+
+FlexWrapper.defaultProps = {
+  flexDirection: 'row',
+  justifyContent: 'flex-start',
+  alignItems: 'baseline',
+  gap: null,
+};
+
+/**
+ * @component FlexWrapper
+ * A flexible layout container for arranging child elements.
+ */
+export default FlexWrapper;

--- a/src/Layout/index.ts
+++ b/src/Layout/index.ts
@@ -7,3 +7,4 @@ export { default as MenuFlex } from './MenuFlex';
 export { default as Callout } from './Callout';
 export { default as GridWrapper } from './GridWrapper';
 export { default as GridContainer } from './GridContainer';
+export { default as FlexWrapper } from './FlexWrapper';


### PR DESCRIPTION
## Describe your changes
This code adds a new FlexWrapper component for arranging child components. The component has display set to `flex` and the standard CSS values for `flex-direction`, `justify-content`, and `align-items` are available. The component also has a `gap` property that uses the DefaultTheme whitespace values to manage spacing between items. 

### Acceptance Criteria
The new component should:
- [x] use `display: flex` for layout
- [x] support `flex-direction`, `justify-content`, and `align-items` properties using `csstype` package to provide values

### Testing Steps / QA Criteria

- Check that the new component properly allows the user to pass in the standard CSS values for `flex-direction`, `justify-content`, and `align-items`
- Check that the user can pass in the gap values defined by `DeafultTheme` `ws` values
- Check that the md file has a clear description of this component and that examples properly showcase how to use this component

## Quality Control
<!--
  Go over all the following points, and put an `x` in all the boxes that apply (not all may be applicable).
-->
- [x] I have run `eslint` on the code
- [x] I have added JSDoc for all of my code
- [ ] I have added tests to cover my changes
- [x] I have checked for typos
- [x] I have reviewed the files for any other issues

### UI Accessibility Checklist

- [ ] [Semantic Markup](https://accessibility.huit.harvard.edu/use-semantic-elements-regions-and-content): Do all elements have the correct semantic markup?
- [x] [Input Labels](https://accessibility.huit.harvard.edu/provide-accessible-labels-and-instructions): Are there descriptive labels marking each input element, and labels for input groups?
- [ ] [Focus](https://accessibility.huit.harvard.edu/provide-logical-and-visible-focus-indication): Is there an indicator when interactive elements have keyboard focus, and does its order follow a logical sequence?
- [x] [Keyboard](https://accessibility.huit.harvard.edu/support-keyboard-interaction): Can all interactive elements be selected and activated using the keyboard?
- [ ] [Names](https://accessibility.huit.harvard.edu/custom-widgets-and-controls): Do all interactive controls have an accessible descriptive name?
- [ ] [Roles](https://accessibility.huit.harvard.edu/provide-name-role-and-value-information): Do all custom controls and widgets have the correct role (e.g., link, button, tab panel)?
- [ ] [Dynamic Updates](https://accessibility.huit.harvard.edu/provide-notification-dynamic-changes-content): Are all dynamic updates, including error messages, conveyed to assistive technology?
- [x] [Colors](https://accessibility.huit.harvard.edu/avoid-reliance-color): Does the design provide sufficient color contrast? You can use a [contrast checker](https://webaim.org/resources/contrastchecker/) to help.
- [x] [Layouts](https://accessibility.huit.harvard.edu/support-flexibility-and-adaptation): Do page layouts adapt to different window widths and text sizes?
- [ ] [Images](https://accessibility.huit.harvard.edu/provide-accessible-images): Do images and icons have the appropriate text alternative?

I'm not sure if adding `aria-labelledy` is necessary/helpful here?


## Related Issues:

Closes #207 